### PR TITLE
Add GetOffset method on Table

### DIFF
--- a/table.go
+++ b/table.go
@@ -295,6 +295,12 @@ func (t *Table) SetOffset(row, column int) *Table {
 	return t
 }
 
+// GetOffset returns current offset.
+// Refer to SetOffset() for details.
+func (t *Table) GetOffset() (row, column int) {
+	return t.rowOffset, t.columnOffset
+}
+
 // SetSelectedFunc sets a handler which is called whenever the user presses the
 // Enter key on a selected cell/row/column. The handler receives the position of
 // the selection and its cell contents. If entire rows are selected, the column


### PR DESCRIPTION
Firstly, Thank you for your great job!

I propose GetOffset method for Table struct.

## Context

I'm developping application which switching between force scrolling mode and row selectable mode dynamically. (like a `less +F` command option)
I was trying to get current visible rows & cols number and set the top of the visible rows as selected row, by `func (t *Table) Select(row, column int) *Table`.
But the `rowOffset`, `columnOffset` field was private, and no getter method for these.
So I implemented the getter method.

## Use case

```go
	table.SetDoneFunc(func(key tcell.Key) {
		...

		if key == tcell.KeyEnter {
			table.SetSelectable(true, false)
			table.Select(table.GetOffset()) // Set the top of visible rows as selected row.
		}

		if key == tcell.KeyEscape {
			table.SetSelectable(false, false)
		}

		...							
	})
```