### PR TITLE
Expandable column

### DIFF
--- a/demos/presentation/table.go
+++ b/demos/presentation/table.go
@@ -116,6 +116,38 @@ const tableSeparator = `[green]func[white] [yellow]main[white]() {
         [yellow]Run[white]()
 }`
 
+const tableExpanded = `[green]func[white] [yellow]main[white]() {
+    table := tview.[yellow]NewTable[white]().
+        [yellow]SetFixed[white]([red]1[white], [red]1[white]).
+        [yellow]SetExpanded[white]([red]3[white])
+    [yellow]for[white] row := [red]0[white]; row < [red]40[white]; row++ {
+        [yellow]for[white] column := [red]0[white]; column < [red]7[white]; column++ {
+            color := tcell.ColorWhite
+            [yellow]if[white] row == [red]0[white] {
+                color = tcell.ColorYellow
+            } [yellow]else[white] [yellow]if[white] column == [red]0[white] {
+                color = tcell.ColorDarkCyan
+            }
+            align := tview.AlignLeft
+            [yellow]if[white] row == [red]0[white] {
+                align = tview.AlignCenter
+            } [yellow]else[white] [yellow]if[white] column == [red]0[white] || column >= [red]4[white] {
+                align = tview.AlignRight
+            }
+            table.[yellow]SetCell[white](row,
+                column,
+                &tview.TableCell{
+                    Text:  [red]"..."[white],
+                    Color: color,
+                    Align: align,
+                })
+        }
+    }
+    tview.[yellow]NewApplication[white]().
+        [yellow]SetRoot[white](table, true).
+        [yellow]Run[white]()
+}`
+
 const tableBorders = `[green]func[white] [yellow]main[white]() {
     table := tview.[yellow]NewTable[white]().
         [yellow]SetFixed[white]([red]1[white], [red]1[white]).
@@ -296,6 +328,15 @@ func Table(nextSlide func()) (title string, content tview.Primitive) {
 			SetSeparator(tview.GraphicsVertBar)
 		code.Clear()
 		fmt.Fprint(code, tableSeparator)
+	}
+
+	expanded := func() {
+		table.SetBorders(false).
+			SetSelectable(false, false).
+			SetSeparator(' ').
+			SetExpandable(3)
+		code.Clear()
+		fmt.Fprint(code, tableExpanded)
 	}
 
 	borders := func() {

--- a/demos/presentation/table.go
+++ b/demos/presentation/table.go
@@ -314,60 +314,48 @@ func Table(nextSlide func()) (title string, content tview.Primitive) {
 
 	list := tview.NewList()
 
-	basic := func() {
-		table.SetBorders(false).
-			SetSelectable(false, false).
-			SetSeparator(' ')
-		code.Clear()
-		fmt.Fprint(code, tableBasic)
-	}
-
-	separator := func() {
-		table.SetBorders(false).
-			SetSelectable(false, false).
-			SetSeparator(tview.GraphicsVertBar)
-		code.Clear()
-		fmt.Fprint(code, tableSeparator)
-	}
-
-	expanded := func() {
+	// reset will undo any modifications and update the code view
+	reset := func(newCode string) {
 		table.SetBorders(false).
 			SetSelectable(false, false).
 			SetSeparator(' ').
-			SetExpandable(3)
+			SetExpandable(-1)
 		code.Clear()
-		fmt.Fprint(code, tableExpanded)
+		fmt.Fprint(code, newCode)
+	}
+
+	basic := func() {
+		reset(tableBasic)
+	}
+
+	separator := func() {
+		reset(tableSeparator)
+		table.SetSeparator(tview.GraphicsVertBar)
+	}
+
+	expanded := func() {
+		reset(tableExpanded)
+		table.SetExpandable(3)
 	}
 
 	borders := func() {
-		table.SetBorders(true).
-			SetSelectable(false, false)
-		code.Clear()
-		fmt.Fprint(code, tableBorders)
+		reset(tableBorders)
+		table.SetBorders(true)
 	}
 
 	selectRow := func() {
-		table.SetBorders(false).
-			SetSelectable(true, false).
-			SetSeparator(' ')
-		code.Clear()
-		fmt.Fprint(code, tableSelectRow)
+		reset(tableSelectRow)
+		table.SetSelectable(true, false)
 	}
 
 	selectColumn := func() {
-		table.SetBorders(false).
-			SetSelectable(false, true).
-			SetSeparator(' ')
-		code.Clear()
-		fmt.Fprint(code, tableSelectColumn)
+		reset(tableSelectColumn)
+		table.SetSelectable(false, true)
 	}
 
 	selectCell := func() {
-		table.SetBorders(false).
-			SetSelectable(true, true).
-			SetSeparator(' ')
-		code.Clear()
-		fmt.Fprint(code, tableSelectCell)
+		reset(tableSelectCell)
+		table.SetSelectable(true, true)
 	}
 
 	navigate := func() {
@@ -383,6 +371,7 @@ func Table(nextSlide func()) (title string, content tview.Primitive) {
 		AddItem("Basic table", "", 'b', basic).
 		AddItem("Table with separator", "", 's', separator).
 		AddItem("Table with borders", "", 'o', borders).
+		AddItem("Expand column 3 (Item)", "", 'e', expanded).
 		AddItem("Selectable rows", "", 'r', selectRow).
 		AddItem("Selectable columns", "", 'c', selectColumn).
 		AddItem("Selectable cells", "", 'l', selectCell).

--- a/table.go
+++ b/table.go
@@ -601,18 +601,26 @@ ColumnLoop:
 		screen.SetContent(x+colX, y+rowY, ch, nil, borderStyle)
 	}
 
+	// Helper function which returns the width for a column. If there's enough
+	// horizontal space, and the given index matches the expandableColumn,
+	// this will increase a columns width by remaining horizontal space.
+	expandX := width - tableWidth
+	colWidth := func(columnIndex int) (w int) {
+		w = widths[columnIndex]
+		if t.expandableColumn == columnIndex && tableWidth < width {
+			w += expandX
+		}
+		return w
+	}
+
 	// Draw the cells (and borders).
 	var columnX int
 	if !t.borders {
+		expandX++
 		columnX--
 	}
 	for columnIndex, column := range columns {
-		columnWidth := widths[columnIndex]
-
-		// Consume remaining horizontal space.
-		if t.expandableColumn == columnIndex && tableWidth < width {
-			columnWidth += width - tableWidth
-		}
+		columnWidth := colWidth(columnIndex)
 
 		for rowY, row := range rows {
 			if t.borders {
@@ -732,7 +740,7 @@ ColumnLoop:
 		columnX := 0
 		rowSelected := t.rowsSelectable && !t.columnsSelectable && row == t.selectedRow
 		for columnIndex, column := range columns {
-			columnWidth := widths[columnIndex]
+			columnWidth := colWidth(columnIndex)
 			cell := getCell(row, column)
 			if cell == nil {
 				continue


### PR DESCRIPTION
I've added a bit of code to mark a column as "expandable", i.e. to use the remaining horizontal space, effectively making any table a full-width table.

My use case is [`multiping`](https://github.com/digineo/go-ping/tree/master/cmd/multiping), which should align the statistic column on the right, and the host information on the left (kind of like [`mtr`](https://github.com/traviscross/mtr))

![expanded](https://user-images.githubusercontent.com/327411/36816432-0bc5e122-1cde-11e8-8312-bc0d9ad02dbd.png)

For now, only one column can be made "expandable", but the API could later be upgraded to `func (t *Table) SetExpandable(columns ...int) *Table` to allow sharing the remaining space between multiple columns.