### PR TITLE
avoid out of bounds index. fixes #67

### DIFF
--- a/table.go
+++ b/table.go
@@ -619,7 +619,7 @@ ColumnLoop:
 	if tableWidth < width {
 		toDistribute := width - tableWidth
 		for index, expansion := range expansions {
-			if expansionTotal <= 0 {
+			if expansionTotal <= 0 || index >= len(widths) {
 				break
 			}
 			expWidth := toDistribute * expansion / expansionTotal


### PR DESCRIPTION
This doesn't resolve any underlying logic mistake.

But it does prevent the crash. Functionality of table navigation remains intact.