### PR TITLE
Add GetText() method

### DIFF
--- a/treeview.go
+++ b/treeview.go
@@ -105,6 +105,11 @@ func (n *TreeNode) SetChildren(childNodes []*TreeNode) *TreeNode {
 	return n
 }
 
+// GetText returns this node's text.
+func (n *TreeNode) GetText() string {
+	return n.text
+}
+
 // GetChildren returns this node's children.
 func (n *TreeNode) GetChildren() []*TreeNode {
 	return n.children


### PR DESCRIPTION
I find it useful to be able to get the nodes text in the handlers. Also seems more consistent with SetReference that has a GetReference.