### PR TITLE
Don't move cursor on inputfield.SetText() unless necessary

### DIFF
--- a/inputfield.go
+++ b/inputfield.go
@@ -102,7 +102,12 @@ func NewInputField() *InputField {
 // SetText sets the current text of the input field.
 func (i *InputField) SetText(text string) *InputField {
 	i.text = text
-	i.cursorPos = len(text)
+
+	// If the new text is shorter than previous, set cursor to end
+	if tl := len(text); i.cursorPos > tl {
+		i.cursorPos = tl
+	}
+
 	if i.changed != nil {
 		i.changed(text)
 	}


### PR DESCRIPTION
The behavior seen was a separate go routine setting the text of a input field and that always moving the cursor to the end.  This changes leaves the cursor as is unless it most be bound to input limits.