### PR TITLE
change: provide drop-down option text and index as args to selection callback when using (*DropDown).AddOption()

### DIFF
--- a/dropdown.go
+++ b/dropdown.go
@@ -186,10 +186,20 @@ func (d *DropDown) GetFieldWidth() int {
 	return fieldWidth
 }
 
-// AddOption adds a new selectable option to this drop-down. The "selected"
-// callback is called when this option was selected. It may be nil.
-func (d *DropDown) AddOption(text string, selected func()) *DropDown {
-	d.options = append(d.options, &dropDownOption{Text: text, Selected: selected})
+// AddOption adds a new selectable option to this drop-down and installs a
+// callback function which is called when this option was selected. It will be
+// called with the option's text and its index into the options slice. The
+// "selected" parameter may be nil.
+func (d *DropDown) AddOption(text string, selected func(string, int)) *DropDown {
+	index := len(d.options)
+	d.options = append(d.options,
+		&dropDownOption{
+			Text: text,
+			Selected: func() {
+				if selected != nil {
+					selected(text, index)
+				}
+			}})
 	d.list.AddItem(text, "", 0, nil)
 	return d
 }
@@ -198,17 +208,11 @@ func (d *DropDown) AddOption(text string, selected func()) *DropDown {
 // one callback function which is called when one of the options is selected.
 // It will be called with the option's text and its index into the options
 // slice. The "selected" parameter may be nil.
-func (d *DropDown) SetOptions(texts []string, selected func(text string, index int)) *DropDown {
+func (d *DropDown) SetOptions(texts []string, selected func(string, int)) *DropDown {
 	d.list.Clear()
 	d.options = nil
-	for index, text := range texts {
-		func(t string, i int) {
-			d.AddOption(text, func() {
-				if selected != nil {
-					selected(t, i)
-				}
-			})
-		}(text, index)
+	for _, text := range texts {
+		d.AddOption(text, selected)
 	}
 	return d
 }

--- a/list.go
+++ b/list.go
@@ -26,6 +26,9 @@ type List struct {
 	// The index of the currently selected item.
 	currentItem int
 
+	// The offset to ensure our currently selected item remains in view.
+	viewOffset int
+
 	// Whether or not to show the secondary item texts.
 	showSecondaryText bool
 
@@ -226,11 +229,45 @@ func (l *List) Clear() *List {
 
 // Draw draws this primitive onto the screen.
 func (l *List) Draw(screen tcell.Screen) {
+
+	// check if a given value exists within a given closed interval by returning
+	// a value less than zero, greater than zero, or equal to zero if the value
+	// is less than the range minimum, greater than the range maximum, or if the
+	// value exists in the interval (inclusive), respectively.
+	contains := func(item, lo, hi int) int {
+		switch {
+		case item < lo:
+			return -1
+		case item > hi:
+			return 1
+		}
+		return 0
+	}
+
 	l.Box.Draw(screen)
 
 	// Determine the dimensions.
 	x, y, width, height := l.GetInnerRect()
-	bottomLimit := y + height
+	yMax := y + height
+
+	itemHeight := 1
+	if l.showSecondaryText {
+		itemHeight = 2
+	}
+	itemsPerPage := height / itemHeight
+
+	// We want to keep the current selection in view. What is our offset?
+	pos := contains(l.currentItem, l.viewOffset, l.viewOffset+itemsPerPage-1)
+	switch {
+	case pos < 0:
+		l.viewOffset = l.currentItem
+	case pos > 0:
+		l.viewOffset = l.currentItem - (itemsPerPage - 1)
+	default:
+		// Adjust the viewing window if and only if our current position is not
+		// inside the range of what's currently visible. Otherwise, let the user
+		// navigate the list items freely, as in this default case.
+	}
 
 	// Do we show any shortcuts?
 	var showShortcuts bool
@@ -243,25 +280,13 @@ func (l *List) Draw(screen tcell.Screen) {
 		}
 	}
 
-	// We want to keep the current selection in view. What is our offset?
-	var offset int
-	if l.showSecondaryText {
-		if 2*l.currentItem >= height {
-			offset = (2*l.currentItem + 2 - height) / 2
-		}
-	} else {
-		if l.currentItem >= height {
-			offset = l.currentItem + 1 - height
-		}
-	}
-
 	// Draw the list items.
 	for index, item := range l.items {
-		if index < offset {
+		if index < l.viewOffset {
 			continue
 		}
 
-		if y >= bottomLimit {
+		if y >= yMax {
 			break
 		}
 
@@ -289,7 +314,7 @@ func (l *List) Draw(screen tcell.Screen) {
 
 		y++
 
-		if y >= bottomLimit {
+		if y >= yMax {
 			break
 		}
 

--- a/textview.go
+++ b/textview.go
@@ -310,6 +310,12 @@ func (t *TextView) ScrollToEnd() *TextView {
 	return t
 }
 
+// GetScrollOffset returns the number of rows and columns that are skipped at
+// the top left corner when the text view has been scrolled.
+func (t *TextView) GetScrollOffset() (row, column int) {
+	return t.lineOffset, t.columnOffset
+}
+
 // Clear removes all text from the buffer.
 func (t *TextView) Clear() *TextView {
 	t.buffer = nil


### PR DESCRIPTION
rivo/tview#206

this change will break backwards compatibility for anyone using `(*DropDown).AddOption()` as its formal signature is changed. but i'm not convinced it's worth preserving the original and implementing this under a different name as the functionality is basically identical.

also I wasn't sure why `(*DropDown).SetOptions()` had the anon function in the body of its for-loop, so I took the liberty of removing it because it was a little confusing that variable identifiers were being reused at different scopes. 

but even if you want to restore it, one of the variables (`text` I believe) was being captured under the closure even though it was passed in via argument! so that needs to be changed regardless.
