### PR TITLE
Prevent recompilation of regexes

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -12,12 +12,12 @@ import (
 	runewidth "github.com/mattn/go-runewidth"
 )
 
-// TabSize is the number of spaces with which a tab character will be replaced.
 var (
 	openColorRegex  = regexp.MustCompile(`\[([a-zA-Z]*|#[0-9a-zA-Z]*)$`)
 	openRegionRegex = regexp.MustCompile(`\["[a-zA-Z0-9_,;: \-\.]*"?$`)
 	newLineRegex    = regexp.MustCompile(`\r?\n`)
 
+	// TabSize is the number of spaces with which a tab character will be replaced.
 	TabSize = 4
 )
 

--- a/textview.go
+++ b/textview.go
@@ -13,7 +13,13 @@ import (
 )
 
 // TabSize is the number of spaces with which a tab character will be replaced.
-var TabSize = 4
+var (
+	openColorRegex  = regexp.MustCompile(`\[([a-zA-Z]*|#[0-9a-zA-Z]*)$`)
+	openRegionRegex = regexp.MustCompile(`\["[a-zA-Z0-9_,;: \-\.]*"?$`)
+	newLineRegex    = regexp.MustCompile(`\r?\n`)
+
+	TabSize = 4
+)
 
 // textViewIndex contains information about each line displayed in the text
 // view.
@@ -497,8 +503,7 @@ func (t *TextView) Write(p []byte) (n int, err error) {
 
 	// If we have a trailing open dynamic color, exclude it.
 	if t.dynamicColors {
-		openColor := regexp.MustCompile(`\[([a-zA-Z]*|#[0-9a-zA-Z]*)$`)
-		location := openColor.FindIndex(newBytes)
+		location := openColorRegex.FindIndex(newBytes)
 		if location != nil {
 			t.recentBytes = newBytes[location[0]:]
 			newBytes = newBytes[:location[0]]
@@ -507,8 +512,7 @@ func (t *TextView) Write(p []byte) (n int, err error) {
 
 	// If we have a trailing open region, exclude it.
 	if t.regions {
-		openRegion := regexp.MustCompile(`\["[a-zA-Z0-9_,;: \-\.]*"?$`)
-		location := openRegion.FindIndex(newBytes)
+		location := openRegionRegex.FindIndex(newBytes)
 		if location != nil {
 			t.recentBytes = newBytes[location[0]:]
 			newBytes = newBytes[:location[0]]
@@ -516,9 +520,8 @@ func (t *TextView) Write(p []byte) (n int, err error) {
 	}
 
 	// Transform the new bytes into strings.
-	newLine := regexp.MustCompile(`\r?\n`)
 	newBytes = bytes.Replace(newBytes, []byte{'\t'}, bytes.Repeat([]byte{' '}, TabSize), -1)
-	for index, line := range newLine.Split(string(newBytes), -1) {
+	for index, line := range newLineRegex.Split(string(newBytes), -1) {
 		if index == 0 {
 			if len(t.buffer) == 0 {
 				t.buffer = []string{line}


### PR DESCRIPTION
I have noticed that there are some regular expressions in textview.go that get recompiled every time that they are needed.