### PR TITLE
Optimizations for TextView

### DIFF
--- a/table.go
+++ b/table.go
@@ -698,7 +698,7 @@ ColumnLoop:
 		expansion := 0
 		for _, row := range rows {
 			if cell := getCell(row, column); cell != nil {
-				_, _, _, _, _, _, cellWidth := decomposeString(cell.Text, true, false)
+				_, _, _, _, _, _, cellWidth := decomposeString(cell.Text, true, false, true)
 				if cell.MaxWidth > 0 && cell.MaxWidth < cellWidth {
 					cellWidth = cell.MaxWidth
 				}

--- a/textview.go
+++ b/textview.go
@@ -201,7 +201,7 @@ func (t *TextView) SetScrollable(scrollable bool) *TextView {
 // beyond the available width are not displayed.
 func (t *TextView) SetWrap(wrap bool) *TextView {
 	if t.wrap != wrap {
-		t.index = nil
+		t.rebuildIndex()
 	}
 	t.wrap = wrap
 	return t
@@ -214,7 +214,7 @@ func (t *TextView) SetWrap(wrap bool) *TextView {
 // This flag is ignored if the "wrap" flag is false.
 func (t *TextView) SetWordWrap(wrapOnWords bool) *TextView {
 	if t.wordWrap != wrapOnWords {
-		t.index = nil
+		t.rebuildIndex()
 	}
 	t.wordWrap = wrapOnWords
 	return t
@@ -223,9 +223,6 @@ func (t *TextView) SetWordWrap(wrapOnWords bool) *TextView {
 // SetTextAlign sets the text alignment within the text view. This must be
 // either AlignLeft, AlignCenter, or AlignRight.
 func (t *TextView) SetTextAlign(align int) *TextView {
-	if t.align != align {
-		t.index = nil
-	}
 	t.align = align
 	return t
 }
@@ -278,7 +275,7 @@ func (t *TextView) GetText(stripTags bool) string {
 // dynamically. See class description for details.
 func (t *TextView) SetDynamicColors(dynamic bool) *TextView {
 	if t.dynamicColors != dynamic {
-		t.index = nil
+		t.rebuildIndex()
 	}
 	t.dynamicColors = dynamic
 	return t
@@ -288,7 +285,7 @@ func (t *TextView) SetDynamicColors(dynamic bool) *TextView {
 // description for details.
 func (t *TextView) SetRegions(regions bool) *TextView {
 	if t.regions != regions {
-		t.index = nil
+		t.rebuildIndex()
 	}
 	t.regions = regions
 	return t
@@ -366,7 +363,7 @@ func (t *TextView) GetScrollOffset() (row, column int) {
 func (t *TextView) Clear() *TextView {
 	t.buffer = nil
 	t.recentBytes = nil
-	t.index = nil
+	t.rebuildIndex()
 	return t
 }
 
@@ -386,7 +383,7 @@ func (t *TextView) Highlight(regionIDs ...string) *TextView {
 		}
 		t.highlights[id] = struct{}{}
 	}
-	t.index = nil
+	t.rebuildIndex()
 	return t
 }
 
@@ -410,7 +407,7 @@ func (t *TextView) ScrollToHighlight() *TextView {
 	if len(t.highlights) == 0 || !t.scrollable || !t.regions {
 		return t
 	}
-	t.index = nil
+	t.rebuildIndex()
 	t.scrollToHighlights = true
 	t.trackEnd = false
 	return t
@@ -562,34 +559,48 @@ func (t *TextView) Write(p []byte) (n int, err error) {
 		}
 	}
 
-	// Reset the index.
-	t.index = nil
+	// Index the new bytes
+	t.appendIndex()
 
 	return len(p), nil
 }
 
-// reindexBuffer re-indexes the buffer such that we can use it to easily draw
-// the buffer onto the screen. Each line in the index will contain a pointer
-// into the buffer from which on we will print text. It will also contain the
-// color with which the line starts.
-func (t *TextView) reindexBuffer(width int) {
-	if t.index != nil {
-		return // Nothing has changed. We can still use the current index.
-	}
-	t.index = nil
-	t.fromHighlight, t.toHighlight, t.posHighlight = -1, -1, -1
-
-	// If there's no space, there's no index.
-	if width < 1 {
+// appendIndex indexes the new buffer data such that we can use it to easily
+// draw the buffer onto the screen. Each line in the index will contain a
+// pointer into the buffer from which on we will print text. It will also
+// contain the color with which the line starts.
+func (t *TextView) appendIndex() {
+	// The width is unknown, the index cannot be appended
+	if t.lastWidth == 0 && t.wrap {
 		return
+	}
+
+	var lastIndex textViewIndex
+	if len(t.index) > 0 {
+		// Pop the last index, it will be regenerated
+		lastIndex = *(t.index[len(t.index)-1])
+		t.index = t.index[:len(t.index)-1]
 	}
 
 	// Initial states.
 	regionID := ""
 	var highlighted bool
 
-	// Go through each line in the buffer.
-	for bufferIndex, str := range t.buffer {
+	for bufferIndex := lastIndex.Line; bufferIndex < len(t.buffer); bufferIndex++ {
+		var (
+			originalPos, offset int
+			str                 string
+		)
+		if bufferIndex == lastIndex.Line {
+			// Start from the last index line
+			str = t.buffer[bufferIndex][lastIndex.Pos:]
+			originalPos = lastIndex.Pos
+			// Offset used for the tagEnd-related calculations, since they are
+			// now relative to the last indexed line
+			offset = lastIndex.Pos
+		} else {
+			str = t.buffer[bufferIndex]
+		}
 		colorTagIndices, colorTags, regionIndices, regions, escapeIndices, strippedStr, _ := decomposeString(str, t.dynamicColors, t.regions)
 
 		// Split the line if required.
@@ -597,7 +608,7 @@ func (t *TextView) reindexBuffer(width int) {
 		str = strippedStr
 		if t.wrap && len(str) > 0 {
 			for len(str) > 0 {
-				extract := runewidth.Truncate(str, width, "")
+				extract := runewidth.Truncate(str, t.lastWidth, "")
 				if t.wordWrap && len(extract) < len(str) {
 					// Add any spaces from the next line.
 					if spaces := spacePattern.FindStringIndex(str[len(extract):]); spaces != nil && spaces[0] == 0 {
@@ -621,7 +632,7 @@ func (t *TextView) reindexBuffer(width int) {
 
 		// Create index from split lines.
 		var (
-			originalPos, colorPos, regionPos, escapePos  int
+			colorPos, regionPos, escapePos               int
 			foregroundColor, backgroundColor, attributes string
 		)
 		for _, splitLine := range splitLines {
@@ -637,7 +648,7 @@ func (t *TextView) reindexBuffer(width int) {
 			// Shift original position with tags.
 			lineLength := len(splitLine)
 			remainingLength := lineLength
-			tagEnd := originalPos
+			tagEnd := originalPos - offset
 			totalTagLength := 0
 			for {
 				// Which tag comes next?
@@ -666,14 +677,14 @@ func (t *TextView) reindexBuffer(width int) {
 				}
 
 				// Advance.
-				strippedTagStart := nextTag[tagIndex][0] - originalPos - totalTagLength
+				strippedTagStart := nextTag[tagIndex][0] - originalPos - totalTagLength + offset
 				tagEnd = nextTag[tagIndex][1]
 				tagLength := tagEnd - nextTag[tagIndex][0]
 				if nextTag[tagIndex][2] == 2 {
 					tagLength = 1
 				}
 				totalTagLength += tagLength
-				remainingLength = lineLength - (tagEnd - originalPos - totalTagLength)
+				remainingLength = lineLength - (tagEnd - originalPos - totalTagLength + offset)
 
 				// Process the tag.
 				switch nextTag[tagIndex][2] {
@@ -711,6 +722,10 @@ func (t *TextView) reindexBuffer(width int) {
 			line.NextPos = originalPos
 			line.Width = stringWidth(splitLine)
 			t.index = append(t.index, line)
+
+			if line.Width > t.longestLine {
+				t.longestLine = line.Width
+			}
 		}
 
 		// Word-wrapped lines may have trailing whitespace. Remove it.
@@ -726,14 +741,14 @@ func (t *TextView) reindexBuffer(width int) {
 			}
 		}
 	}
+}
 
-	// Calculate longest line.
+// rebuildIndex clears and rebuilds the index
+func (t *TextView) rebuildIndex() {
+	t.index = nil
 	t.longestLine = 0
-	for _, line := range t.index {
-		if line.Width > t.longestLine {
-			t.longestLine = line.Width
-		}
-	}
+
+	t.appendIndex()
 }
 
 // Draw draws this primitive onto the screen.
@@ -748,12 +763,9 @@ func (t *TextView) Draw(screen tcell.Screen) {
 
 	// If the width has changed, we need to reindex.
 	if width != t.lastWidth && t.wrap {
-		t.index = nil
+		t.lastWidth = width
+		t.rebuildIndex()
 	}
-	t.lastWidth = width
-
-	// Re-index.
-	t.reindexBuffer(width)
 
 	// If we don't have an index, there's nothing to draw.
 	if t.index == nil {
@@ -939,7 +951,7 @@ func (t *TextView) Draw(screen tcell.Screen) {
 	// scrolled out of view.
 	if !t.scrollable && t.lineOffset > 0 {
 		t.buffer = t.buffer[t.index[t.lineOffset].Line:]
-		t.index = nil
+		t.rebuildIndex()
 	}
 }
 

--- a/textview.go
+++ b/textview.go
@@ -601,7 +601,7 @@ func (t *TextView) appendIndex() {
 		} else {
 			str = t.buffer[bufferIndex]
 		}
-		colorTagIndices, colorTags, regionIndices, regions, escapeIndices, strippedStr, _ := decomposeString(str, t.dynamicColors, t.regions)
+		colorTagIndices, colorTags, regionIndices, regions, escapeIndices, strippedStr, _ := decomposeString(str, t.dynamicColors, t.regions, false)
 
 		// Split the line if required.
 		var splitLines []string
@@ -852,7 +852,7 @@ func (t *TextView) Draw(screen tcell.Screen) {
 		regionID := index.Region
 
 		// Process tags.
-		colorTagIndices, colorTags, regionIndices, regions, escapeIndices, strippedText, _ := decomposeString(text, t.dynamicColors, t.regions)
+		colorTagIndices, colorTags, regionIndices, regions, escapeIndices, strippedText, _ := decomposeString(text, t.dynamicColors, t.regions, false)
 
 		// Calculate the position of the line.
 		var skip, posX int


### PR DESCRIPTION
Only clear the index when the textview dimensions change or the text
itself is cleared.
Add to the index when new text is added to the view.

Fixes #266