### PR TITLE
Added traceEnd=false when scrolling

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -327,6 +327,7 @@ func (t *TextView) ScrollTo(row, column int) *TextView {
 	if !t.scrollable {
 		return t
 	}
+	t.trackEnd = false
 	t.lineOffset = row
 	t.columnOffset = column
 	return t


### PR DESCRIPTION
I have *not* done a lot of research, so this might NOT be the right way of fixing the `.ScrollTo(row,column)` not-working-issue.

I found that the `TextView` sets `trackEnd=false` when scrolling up on `PgUP` but if you want to scroll based on _external_ event it is not working.

Anyway.. This patch fixed my issue, :)