### PR TITLE
Added GetFormItems()

### DIFF
--- a/form.go
+++ b/form.go
@@ -302,6 +302,12 @@ func (f *Form) GetFormItem(index int) FormItem {
 	return f.items[index]
 }
 
+// GetFormItems returns a slice of all form elements exluding Buttons.
+// Elements are returned in the order they were added.
+func (f *Form) GetFormItems() []FormItem {
+	return f.items
+}
+
 // RemoveFormItem removes the form element at the given position, starting with
 // index 0. Elements are referenced in the order they were added. Buttons are
 // not included.


### PR DESCRIPTION
As I could not find a current way to determine the number of form items from code written outside of the `tview.Form` class, the `GetFormItem(n)` method can't be used reliably if the number of fields is unknown.  For my use case I wanted to iterate all of them so I am submitting this pull request that would allow a developer to do so.

Hopefully this is simple and obvious enough of a change that it will be a no-brainer to commit.