### PR TITLE
Added a ChangedFunc to Form

### DIFF
--- a/form.go
+++ b/form.go
@@ -79,6 +79,9 @@ type Form struct {
 
 	// An optional function which is called when the user hits Escape.
 	cancel func()
+
+	// An optional function which is called when the form item changes.
+	changed func(item FormItem)
 }
 
 // NewForm returns a new form.
@@ -341,6 +344,13 @@ func (f *Form) SetCancelFunc(callback func()) *Form {
 	return f
 }
 
+// SetChangedFunc sets a handler which is called when the user moves to
+// another field in the form.
+func (f *Form) SetChangedFunc(callback func(item FormItem)) *Form {
+	f.changed = callback
+	return f
+}
+
 // Draw draws this primitive onto the screen.
 func (f *Form) Draw(screen tcell.Screen) {
 	f.Box.Draw(screen)
@@ -562,6 +572,9 @@ func (f *Form) Focus(delegate func(p Primitive)) {
 		item := f.items[f.focusedElement]
 		item.SetFinishedFunc(handler)
 		delegate(item)
+		if f.changed != nil {
+			f.changed(f.items[f.focusedElement])
+		}
 	} else {
 		// We're selecting a button.
 		button := f.buttons[f.focusedElement-len(f.items)]


### PR DESCRIPTION
I want to display help for each field, but to do so I need to be called right after a field changes and not before.

I could have hacked it and used the InputField and CheckBox `ChangeFuncs`, but DropDown did not have one and if I was going to add one why not add for the form?

What my PR does not address is changes with buttons, because Button does not implement `FormItem`, although I think it should since it is actually an item on a form. If it were a FormItem them my changed code could work for both.

If you agree, I'll be happy to add the required code to make `Button` a `FormItem` to this PR.  Or you can just accept this PR.  

Or neither _(but I hope you will accept it, otherwise I'll have to live with a fork.)_