### PR TITLE
Added FormItem Validation

### DIFF
--- a/application.go
+++ b/application.go
@@ -228,6 +228,11 @@ EventLoop:
 					a.Stop()
 				}
 
+				// Allow a validation to short-circuit input handling
+				if !a.ValidatePrimitive(p, event) {
+					continue
+				}
+
 				// Pass other key events to the currently focused primitive.
 				if p != nil {
 					if handler := p.InputHandler(); handler != nil {
@@ -502,4 +507,53 @@ func (a *Application) QueueUpdateDraw(f func()) *Application {
 func (a *Application) QueueEvent(event tcell.Event) *Application {
 	a.events <- event
 	return a
+}
+
+// ValidatePrimitive will call a validation function specific to
+// a FormItem set using the SetValidateFunc() methods when one of
+// the field exit keys — Enter, Tab, Backtab, or Escape — is used.
+// If the validation function returns false the focus will stay on
+// the non-valid form field.
+func (a *Application) ValidatePrimitive(p Primitive, event *tcell.EventKey) bool {
+	switch event.Key() {
+	case tcell.KeyEnter, tcell.KeyTab, tcell.KeyBacktab, tcell.KeyEscape:
+		// We will check validation below
+	default:
+		// No need to check
+		return true
+	}
+	switch p.(type) {
+	case *InputField:
+		i := p.(*InputField)
+		if i.valid == nil {
+			break
+		}
+		return i.valid(i, event)
+
+	case *DropDown:
+		dd := p.(*DropDown)
+		if dd.valid == nil {
+			break
+		}
+		return dd.valid(dd, event)
+
+	case *Checkbox:
+		cb := p.(*Checkbox)
+		if cb.valid == nil {
+			break
+		}
+		return cb.valid(cb, event)
+
+	default:
+		b, ok := p.(*Box)
+		if !ok {
+			break
+		}
+		if b.valid == nil {
+			break
+		}
+		return b.valid(p, event)
+
+	}
+	return true
 }

--- a/box.go
+++ b/box.go
@@ -58,6 +58,11 @@ type Box struct {
 
 	// An optional function which is called before the box is drawn.
 	draw func(screen tcell.Screen, x, y, width, height int) (int, int, int, int)
+
+	// A callback function to be called when one of the field exit keys — Enter,
+	// Tab, Backtab, or Escape — is used. If this callback returns false it will
+	// bypass the input handler and leave the focus on the non-valid field.
+	valid func(Primitive, *tcell.EventKey) bool
 }
 
 // NewBox returns a Box without a border.
@@ -228,6 +233,14 @@ func (b *Box) SetTitleColor(color tcell.Color) *Box {
 // or AlignRight.
 func (b *Box) SetTitleAlign(align int) *Box {
 	b.titleAlign = align
+	return b
+}
+
+// SetValidateFunc sets a callback to be called when one of the field exit keys —
+// Enter, Tab, Backtab, or Escape — is used. If this callback returns false it
+// will stop the input handler from moving focus to a different field.
+func (b *Box) SetValidateFunc(handler func(Primitive, *tcell.EventKey) bool) *Box {
+	b.valid = handler
 	return b
 }
 

--- a/checkbox.go
+++ b/checkbox.go
@@ -42,6 +42,11 @@ type Checkbox struct {
 	// A callback function set by the Form class and called when the user leaves
 	// this form item.
 	finished func(tcell.Key)
+
+	// A callback function to be called when one of the field exit keys — Enter,
+	// Tab, Backtab, or Escape — is used. If this callback returns false it will
+	// bypass the input handler and leave the focus on the non-valid field.
+	valid func(*Checkbox, *tcell.EventKey) bool
 }
 
 // NewCheckbox returns a new input field.
@@ -139,6 +144,14 @@ func (c *Checkbox) SetDoneFunc(handler func(key tcell.Key)) *Checkbox {
 // SetFinishedFunc sets a callback invoked when the user leaves this form item.
 func (c *Checkbox) SetFinishedFunc(handler func(key tcell.Key)) FormItem {
 	c.finished = handler
+	return c
+}
+
+// SetValidateFunc sets a callback to be called when one of the field exit keys —
+// Enter, Tab, Backtab, or Escape — is used. If this callback returns false it
+// will stop the input handler from moving focus to a different field.
+func (c *Checkbox) SetValidateFunc(handler func(*Checkbox, *tcell.EventKey) bool) *Checkbox {
+	c.valid = handler
 	return c
 }
 
@@ -254,11 +267,16 @@ type CheckboxArgs struct {
 	// returns the event to be forwarded to the primitive's default
 	// input handler (nil if nothing should be forwarded).
 	InputCaptureFunc func(event *tcell.EventKey) *tcell.EventKey
+
+	// A callback function to be called when one of the field exit keys — Enter,
+	// Tab, Backtab, or Escape — is used. If this callback returns false it will
+	// bypass the input handler and leave the focus on the non-valid field.
+	ValidateFunc func(*Checkbox, *tcell.EventKey) bool
 }
 
 // ApplyArgs applies the values from a CheckboxArgs{} struct to the
 // associated properties of the Checkbox.
-func (c *Checkbox) ApplyArgs(args *CheckboxArgs) *Checkbox{
+func (c *Checkbox) ApplyArgs(args *CheckboxArgs) *Checkbox {
 
 	c.SetLabel(args.Label)
 	c.SetChecked(args.Checked)
@@ -288,9 +306,11 @@ func (c *Checkbox) ApplyArgs(args *CheckboxArgs) *Checkbox{
 	if args.FinishedFunc != nil {
 		c.SetFinishedFunc(args.FinishedFunc)
 	}
+	if args.ValidateFunc != nil {
+		c.SetValidateFunc(args.ValidateFunc)
+	}
 	if args.InputCaptureFunc != nil {
 		c.SetInputCapture(args.InputCaptureFunc)
 	}
 	return c
 }
-

--- a/checkbox.go
+++ b/checkbox.go
@@ -201,3 +201,96 @@ func (c *Checkbox) InputHandler() func(event *tcell.EventKey, setFocus func(p Pr
 		}
 	})
 }
+
+// CheckboxArgs provides a concise and readable way to initialize
+// all the properties of the Checkbox struct by passing to the
+// <form>.AddFormItem(item,args).
+type CheckboxArgs struct {
+	baseFormItemArgs
+
+	// The text to be displayed before the input area.
+	Label string
+
+	// Whether or not this box is checked.
+	Checked bool
+
+	// An optional function which is called when the user changes
+	// the checked state of this checkbox.
+	ChangedFunc func(checked bool)
+
+	// The screen width of the input area. A value of 0 means extend
+	// as much as possible.
+	FieldWidth int
+
+	// The screen width of the label area. A value of 0 means use
+	// the width of the label text.
+	LabelWidth int
+
+	// The label color.
+	LabelColor tcell.Color
+
+	// The background color of the input area.
+	FieldBackgroundColor tcell.Color
+
+	// The text color of the input area.
+	FieldTextColor tcell.Color
+
+	// The background color of the input area.
+	BackgroundColor tcell.Color
+
+	// An optional function which is called when the user indicated
+	// that they are done entering text. The key which was pressed
+	// is provided (tab, shift-tab, enter, or escape).
+	DoneFunc func(key tcell.Key)
+
+	// A callback function set by the Form class and called when
+	// the user leaves this form item.
+	FinishedFunc func(key tcell.Key)
+
+	// An optional function which is called before the box is drawn.
+	DrawFunc func(screen tcell.Screen, x, y, width, height int) (int, int, int, int)
+
+	// An optional capture function which receives a key event and
+	// returns the event to be forwarded to the primitive's default
+	// input handler (nil if nothing should be forwarded).
+	InputCaptureFunc func(event *tcell.EventKey) *tcell.EventKey
+}
+
+// ApplyArgs applies the values from a CheckboxArgs{} struct to the
+// associated properties of the Checkbox.
+func (c *Checkbox) ApplyArgs(args *CheckboxArgs) *Checkbox{
+
+	c.SetLabel(args.Label)
+	c.SetChecked(args.Checked)
+	c.SetChangedFunc(args.ChangedFunc)
+
+	if args.LabelWidth > 0 {
+		c.SetLabelWidth(args.LabelWidth)
+	}
+	if args.LabelColor != 0 {
+		c.SetLabelColor(args.LabelColor)
+	}
+	if args.FieldBackgroundColor != 0 {
+		c.SetFieldBackgroundColor(args.FieldBackgroundColor)
+	}
+	if args.FieldTextColor != 0 {
+		c.SetFieldTextColor(args.FieldTextColor)
+	}
+	if args.BackgroundColor != 0 {
+		c.SetBackgroundColor(args.BackgroundColor)
+	}
+	if args.DoneFunc != nil {
+		c.SetDoneFunc(args.DoneFunc)
+	}
+	if args.DrawFunc != nil {
+		c.SetDrawFunc(args.DrawFunc)
+	}
+	if args.FinishedFunc != nil {
+		c.SetFinishedFunc(args.FinishedFunc)
+	}
+	if args.InputCaptureFunc != nil {
+		c.SetInputCapture(args.InputCaptureFunc)
+	}
+	return c
+}
+

--- a/dropdown.go
+++ b/dropdown.go
@@ -70,6 +70,11 @@ type DropDown struct {
 	// A callback function which is called when the user changes the drop-down's
 	// selection.
 	selected func(text string, index int)
+
+	// A callback function to be called when one of the field exit keys — Enter,
+	// Tab, Backtab, or Escape — is used. If this callback returns false it will
+	// bypass the input handler and leave the focus on the non-valid field.
+	valid func(*DropDown, *tcell.EventKey) bool
 }
 
 // NewDropDown returns a new drop-down.
@@ -253,6 +258,14 @@ func (d *DropDown) SetDoneFunc(handler func(key tcell.Key)) *DropDown {
 // SetFinishedFunc sets a callback invoked when the user leaves this form item.
 func (d *DropDown) SetFinishedFunc(handler func(key tcell.Key)) FormItem {
 	d.finished = handler
+	return d
+}
+
+// SetValidateFunc sets a callback to be called when one of the field exit keys —
+// Enter, Tab, Backtab, or Escape — is used. If this callback returns false it
+// will stop the input handler from moving focus to a different field.
+func (d *DropDown) SetValidateFunc(handler func(*DropDown, *tcell.EventKey) bool) *DropDown {
+	d.valid = handler
 	return d
 }
 
@@ -499,8 +512,10 @@ type DropDownArgs struct {
 	// returns the event to be forwarded to the primitive's default
 	// input handler (nil if nothing should be forwarded).
 	InputCaptureFunc func(event *tcell.EventKey) *tcell.EventKey
-}
 
+	// An optional function which is called before the box is drawn.
+	ValidateFunc func(*DropDown, *tcell.EventKey) bool
+}
 
 // ApplyArgs applies the values from a DropDownArgs{} struct to the
 // associated properties of the DropDown.
@@ -536,6 +551,9 @@ func (d *DropDown) ApplyArgs(args *DropDownArgs) *DropDown {
 	}
 	if args.FinishedFunc != nil {
 		d.SetFinishedFunc(args.FinishedFunc)
+	}
+	if args.ValidateFunc != nil {
+		d.SetValidateFunc(args.ValidateFunc)
 	}
 	if args.InputCaptureFunc != nil {
 		d.SetInputCapture(args.InputCaptureFunc)

--- a/dropdown.go
+++ b/dropdown.go
@@ -439,3 +439,106 @@ func (d *DropDown) HasFocus() bool {
 	}
 	return d.hasFocus
 }
+
+// DropDownArgs provides a concise and readable way to initialize
+// all the properties of the DropDown struct by passing to the
+// <form>.AddFormItem(item,args).
+type DropDownArgs struct {
+	baseFormItemArgs
+
+	// The text to be displayed before the input area.
+	Label string
+
+	// The options from which the user can choose.
+	Options []string
+
+	// The index of the initial selected option. Negative if no option
+	// should be selected.
+	InitialOption int
+
+	// The color for prefixes.
+	PrefixTextColor tcell.Color
+
+	// A callback function which is called when the user changes
+	// the drop-down's selection.
+	SelectedFunc func(option string, optionIndex int)
+
+	// The screen width of the input area. A value of 0 means extend
+	// as much as possible.
+	FieldWidth int
+
+	// The screen width of the label area. A value of 0 means use
+	// the width of the label text.
+	LabelWidth int
+
+	// The label color.
+	LabelColor tcell.Color
+
+	// The background color of the input area.
+	FieldBackgroundColor tcell.Color
+
+	// The text color of the input area.
+	FieldTextColor tcell.Color
+
+	// The background color of the input area.
+	BackgroundColor tcell.Color
+
+	// An optional function which is called when the user indicated
+	// that they are done entering text. The key which was pressed
+	// is provided (tab, shift-tab, enter, or escape).
+	DoneFunc func(key tcell.Key)
+
+	// A callback function set by the Form class and called when
+	// the user leaves this form item.
+	FinishedFunc func(key tcell.Key)
+
+	// An optional function which is called before the box is drawn.
+	DrawFunc func(screen tcell.Screen, x, y, width, height int) (int, int, int, int)
+
+	// An optional capture function which receives a key event and
+	// returns the event to be forwarded to the primitive's default
+	// input handler (nil if nothing should be forwarded).
+	InputCaptureFunc func(event *tcell.EventKey) *tcell.EventKey
+}
+
+
+// ApplyArgs applies the values from a DropDownArgs{} struct to the
+// associated properties of the DropDown.
+func (d *DropDown) ApplyArgs(args *DropDownArgs) *DropDown {
+	d.SetLabel(args.Label)
+	d.SetFieldWidth(args.FieldWidth)
+	d.SetOptions(args.Options, args.SelectedFunc)
+	d.SetCurrentOption(args.InitialOption)
+
+	if args.LabelWidth > 0 {
+		d.SetLabelWidth(args.LabelWidth)
+	}
+	if args.LabelColor != 0 {
+		d.SetLabelColor(args.LabelColor)
+	}
+	if args.FieldBackgroundColor != 0 {
+		d.SetFieldBackgroundColor(args.FieldBackgroundColor)
+	}
+	if args.FieldTextColor != 0 {
+		d.SetFieldTextColor(args.FieldTextColor)
+	}
+	if args.BackgroundColor != 0 {
+		d.SetBackgroundColor(args.BackgroundColor)
+	}
+	if args.PrefixTextColor != 0 {
+		d.SetPrefixTextColor(args.PrefixTextColor)
+	}
+	if args.DoneFunc != nil {
+		d.SetDoneFunc(args.DoneFunc)
+	}
+	if args.DrawFunc != nil {
+		d.SetDrawFunc(args.DrawFunc)
+	}
+	if args.FinishedFunc != nil {
+		d.SetFinishedFunc(args.FinishedFunc)
+	}
+	if args.InputCaptureFunc != nil {
+		d.SetInputCapture(args.InputCaptureFunc)
+	}
+	return d
+}

--- a/formitemargs.go
+++ b/formitemargs.go
@@ -1,0 +1,48 @@
+package tview
+
+// FormItemArgs is a collection of interfaces and structs to effectively
+// provide a concise and readable method to initialize all the properties
+// of the various FormItem structs provided by tview, e.g. InputFieldArgs,
+// PasswordFieldArgs, DropDownArgs and CheckboxArgs.
+//
+// This is an alternate to calling the <form>.Add___() methods like
+// AddInputField(), AddPasswordField(),  AddDropDown() and  AddCheckbox().
+//
+// To use these structs pass them to <form>.AddFormItem(item,args)
+//
+// See https://github.com/rivo/tview/wiki/FormItemArgs for an example.
+
+// FormItemArgsImplementor is an interface that indicates to Go
+// that the implementing struct should be allowed to be used as
+// a valid `args` parameter in the collection of `Apply___Args()`
+// methods.
+// Someone implementing their own FormItem struct may also want
+// to implement their own associated "Args" struct and implement
+// this interface to allow uses of their FormItem to fully
+// instantiate it using <form>.AddFormItem(item,args)
+type FormItemArgsImplementor interface {
+	ImplementsFormItemArgs()
+}
+
+// FormItemArgsApplier is an interface that allows someone to
+// implement their an ApplyArgs(arg) method for their own custom
+// FormItem so that <form>.ApplyFormItemArgs(item,args) can be
+// called by the user of the FormItem in the same manner that
+// the tview-builtin FormItem types can be used.
+type FormItemArgsApplier interface {
+	ApplyArgs(FormItemArgsImplementor) FormItem
+}
+
+// baseFormItemArgs is merely a convenience struct that can be
+// embedded in another struct — e.g. InputFieldArgs, PasswordFieldArgs,
+// DropDownArgs and CheckboxArgs — as a shortcut to having to
+// add an ImplementsFormItemArgs() method in order to implement
+// the FormItemArgsImplementor interface
+type baseFormItemArgs struct{}
+
+// ImplementsFormItemArgs implements the FormItemArgsImplementor
+// interface in the baseFormItemArgs struct so the struct can be
+// embedded in other structs — e.g. InputFieldArgs, PasswordFieldArgs,
+// DropDownArgs and CheckboxArgs — as a shortcut to them having
+// to each add their own ImplementsFormItemArgs() method.
+func (baseFormItemArgs) ImplementsFormItemArgs() {}

--- a/inputfield.go
+++ b/inputfield.go
@@ -85,6 +85,11 @@ type InputField struct {
 	// A callback function set by the Form class and called when the user leaves
 	// this form item.
 	finished func(tcell.Key)
+
+	// A callback function to be called when one of the field exit keys — Enter,
+	// Tab, Backtab, or Escape — is used. If this callback returns false it will
+	// bypass the input handler and leave the focus on the non-valid field.
+	valid func(*InputField, *tcell.EventKey) bool
 }
 
 // NewInputField returns a new input field.
@@ -223,6 +228,14 @@ func (i *InputField) SetDoneFunc(handler func(key tcell.Key)) *InputField {
 // SetFinishedFunc sets a callback invoked when the user leaves this form item.
 func (i *InputField) SetFinishedFunc(handler func(key tcell.Key)) FormItem {
 	i.finished = handler
+	return i
+}
+
+// SetValidateFunc sets a callback to be called when one of the field exit keys —
+// Enter, Tab, Backtab, or Escape — is used. If this callback returns false it
+// will stop the input handler from moving focus to a different field.
+func (i *InputField) SetValidateFunc(handler func(*InputField, *tcell.EventKey) bool) *InputField {
+	i.valid = handler
 	return i
 }
 
@@ -507,6 +520,9 @@ type InputFieldArgs struct {
 	// returns the event to be forwarded to the primitive's default
 	// input handler (nil if nothing should be forwarded).
 	InputCaptureFunc func(event *tcell.EventKey) *tcell.EventKey
+
+	// An optional function which is called before the box is drawn.
+	ValidateFunc func(*InputField, *tcell.EventKey) bool
 }
 
 // ApplyArgs applies the values from a InputFieldArgs{} or PasswordFieldArgs{}
@@ -563,10 +579,11 @@ func (i *InputField) applyInputFieldArgs(args *InputFieldArgs) *InputField {
 	if args.FinishedFunc != nil {
 		i.SetFinishedFunc(args.FinishedFunc)
 	}
+	if args.ValidateFunc != nil {
+		i.SetValidateFunc(args.ValidateFunc)
+	}
 	if args.InputCaptureFunc != nil {
 		i.SetInputCapture(args.InputCaptureFunc)
 	}
 	return i
 }
-
-

--- a/inputfield.go
+++ b/inputfield.go
@@ -445,3 +445,128 @@ func (i *InputField) InputHandler() func(event *tcell.EventKey, setFocus func(p 
 		}
 	})
 }
+
+// InputFieldArgs provides a concise and readable way to initialize
+// all the properties of the InputField struct by passing to the
+// <form>.AddFormItem(item,args).
+type InputFieldArgs struct {
+	baseFormItemArgs
+
+	// The text to be displayed before the input area.
+	Label string
+
+	// The text that was entered.
+	Text string
+
+	// The text to be displayed in the input area when "text" is empty.
+	Placeholder string
+
+	// The text color of the placeholder.
+	PlaceholderTextColor tcell.Color
+
+	// An optional function which may reject the last character that
+	// was entered.
+	AcceptanceFunc func(textToCheck string, lastChar rune) bool
+
+	// An optional function which is called when the input has changed.
+	ChangedFunc func(text string)
+
+	// The screen width of the input area. A value of 0 means extend
+	// as much as possible.
+	FieldWidth int
+
+	// The screen width of the label area. A value of 0 means use
+	// the width of the label text.
+	LabelWidth int
+
+	// The label color.
+	LabelColor tcell.Color
+
+	// The background color of the input area.
+	FieldBackgroundColor tcell.Color
+
+	// The text color of the input area.
+	FieldTextColor tcell.Color
+
+	// The background color of the input area.
+	BackgroundColor tcell.Color
+
+	// An optional function which is called when the user indicated
+	// that they are done entering text. The key which was pressed
+	// is provided (tab, shift-tab, enter, or escape).
+	DoneFunc func(key tcell.Key)
+
+	// A callback function set by the Form class and called when
+	// the user leaves this form item.
+	FinishedFunc func(key tcell.Key)
+
+	// An optional function which is called before the box is drawn.
+	DrawFunc func(screen tcell.Screen, x, y, width, height int) (int, int, int, int)
+
+	// An optional capture function which receives a key event and
+	// returns the event to be forwarded to the primitive's default
+	// input handler (nil if nothing should be forwarded).
+	InputCaptureFunc func(event *tcell.EventKey) *tcell.EventKey
+}
+
+// ApplyArgs applies the values from a InputFieldArgs{} or PasswordFieldArgs{}
+// struct to the associated properties of the PasswordField of its respective
+// field.
+func (i *InputField) ApplyArgs(args FormItemArgsImplementor) (item FormItem) {
+	switch args.(type) {
+	case *InputFieldArgs:
+		item = i.applyInputFieldArgs(args.(*InputFieldArgs))
+		break
+	case *PasswordFieldArgs:
+		item = i.applyPasswordFieldArgs(args.(*PasswordFieldArgs))
+		break
+	}
+	return item
+}
+
+// applyInputFieldArgs applies the values from a InputFieldArgs{}
+// struct to the associated properties of the InputField.
+func (i *InputField) applyInputFieldArgs(args *InputFieldArgs) *InputField {
+	i.SetLabel(args.Label)
+	i.SetText(args.Text)
+	i.SetFieldWidth(args.FieldWidth)
+	i.SetAcceptanceFunc(args.AcceptanceFunc)
+	i.SetChangedFunc(args.ChangedFunc)
+
+	if args.Placeholder != "" {
+		i.SetPlaceholder(args.Placeholder)
+	}
+	if args.LabelWidth > 0 {
+		i.SetLabelWidth(args.LabelWidth)
+	}
+	if args.LabelColor != 0 {
+		i.SetLabelColor(args.LabelColor)
+	}
+	if args.FieldBackgroundColor != 0 {
+		i.SetFieldBackgroundColor(args.FieldBackgroundColor)
+	}
+	if args.FieldTextColor != 0 {
+		i.SetFieldTextColor(args.FieldTextColor)
+	}
+	if args.BackgroundColor != 0 {
+		i.SetBackgroundColor(args.BackgroundColor)
+	}
+	if args.PlaceholderTextColor != 0 {
+		i.SetPlaceholderTextColor(args.PlaceholderTextColor)
+	}
+	if args.DoneFunc != nil {
+		i.SetDoneFunc(args.DoneFunc)
+	}
+	if args.DrawFunc != nil {
+		i.SetDrawFunc(args.DrawFunc)
+	}
+	if args.FinishedFunc != nil {
+		i.SetFinishedFunc(args.FinishedFunc)
+	}
+	if args.InputCaptureFunc != nil {
+		i.SetInputCapture(args.InputCaptureFunc)
+	}
+	return i
+}
+
+

--- a/passwordfield.go
+++ b/passwordfield.go
@@ -1,0 +1,107 @@
+package tview
+
+import "github.com/gdamore/tcell"
+
+// NewPasswordField returns a new input field intended for use as a password.
+// This is primarily here to make addition of a password field more readable
+// when calling Form.AddFormItem(NewPasswordField(),&PasswordFieldArgs{...})
+func NewPasswordField() *InputField {
+	return NewInputField()
+}
+
+// PasswordFieldArgs provides a concise and readable way to initialize
+// all the properties of the PasswordField struct by passing to the
+// <form>.AddFormItem(item,args).
+type PasswordFieldArgs struct {
+	baseFormItemArgs
+
+	// The text to be displayed before the input area.
+	Label string
+
+	// The text that was entered.
+	Text string
+
+	// A character to mask entered text (useful for password fields).
+	// A value of 0 disables masking.
+	MaskCharacter rune
+
+	// An optional function which is called when the input has changed.
+	ChangedFunc func(text string)
+
+	// The screen width of the input area. A value of 0 means extend
+	// as much as possible.
+	FieldWidth int
+
+	// The screen width of the label area. A value of 0 means use
+	// the width of the label text.
+	LabelWidth int
+
+	// The label color.
+	LabelColor tcell.Color
+
+	// The background color of the input area.
+	FieldBackgroundColor tcell.Color
+
+	// The text color of the input area.
+	FieldTextColor tcell.Color
+
+	// The background color of the input area.
+	BackgroundColor tcell.Color
+
+	// An optional function which is called when the user indicated
+	// that they are done entering text. The key which was pressed
+	// is provided (tab, shift-tab, enter, or escape).
+	DoneFunc func(key tcell.Key)
+
+	// A callback function set by the Form class and called when
+	// the user leaves this form item.
+	FinishedFunc func(key tcell.Key)
+
+	// An optional function which is called before the box is drawn.
+	DrawFunc func(screen tcell.Screen, x, y, width, height int) (int, int, int, int)
+
+	// An optional capture function which receives a key event and
+	// returns the event to be forwarded to the primitive's default
+	// input handler (nil if nothing should be forwarded).
+	InputCaptureFunc func(event *tcell.EventKey) *tcell.EventKey
+}
+
+// applyPasswordFieldArgs applies the values from a PasswordFieldArgs{}
+// struct to the associated properties of the PasswordField.
+func (i *InputField) applyPasswordFieldArgs(args *PasswordFieldArgs) *InputField {
+	i.SetLabel(args.Label)
+	i.SetText(args.Text)
+	i.SetFieldWidth(args.FieldWidth)
+	i.SetMaskCharacter(args.MaskCharacter)
+	i.SetChangedFunc(args.ChangedFunc)
+
+	if args.LabelWidth > 0 {
+		i.SetLabelWidth(args.LabelWidth)
+	}
+	if args.LabelColor != 0 {
+		i.SetLabelColor(args.LabelColor)
+	}
+	if args.FieldBackgroundColor != 0 {
+		i.SetFieldBackgroundColor(args.FieldBackgroundColor)
+	}
+	if args.FieldTextColor != 0 {
+		i.SetFieldTextColor(args.FieldTextColor)
+	}
+	if args.BackgroundColor != 0 {
+		i.SetBackgroundColor(args.BackgroundColor)
+	}
+	if args.DoneFunc != nil {
+		i.SetDoneFunc(args.DoneFunc)
+	}
+	if args.DrawFunc != nil {
+		i.SetDrawFunc(args.DrawFunc)
+	}
+	if args.FinishedFunc != nil {
+		i.SetFinishedFunc(args.FinishedFunc)
+	}
+	if args.InputCaptureFunc != nil {
+		i.SetInputCapture(args.InputCaptureFunc)
+	}
+	return i
+}
+

--- a/passwordfield.go
+++ b/passwordfield.go
@@ -64,6 +64,9 @@ type PasswordFieldArgs struct {
 	// returns the event to be forwarded to the primitive's default
 	// input handler (nil if nothing should be forwarded).
 	InputCaptureFunc func(event *tcell.EventKey) *tcell.EventKey
+
+	// An optional function which is called before the box is drawn.
+	ValidateFunc func(*InputField, *tcell.EventKey) bool
 }
 
 // applyPasswordFieldArgs applies the values from a PasswordFieldArgs{}
@@ -99,9 +102,11 @@ func (i *InputField) applyPasswordFieldArgs(args *PasswordFieldArgs) *InputField
 	if args.FinishedFunc != nil {
 		i.SetFinishedFunc(args.FinishedFunc)
 	}
+	if args.ValidateFunc != nil {
+		i.SetValidateFunc(args.ValidateFunc)
+	}
 	if args.InputCaptureFunc != nil {
 		i.SetInputCapture(args.InputCaptureFunc)
 	}
 	return i
 }
-

--- a/validation.go
+++ b/validation.go
@@ -1,0 +1,7 @@
+package tview
+
+import "github.com/gdamore/tcell"
+
+type PrimitiveValidationHandler interface {
+	Validate(p Primitive, key *tcell.EventKey) bool
+}


### PR DESCRIPTION
This PR includes the commits for #300 because it is too hard to use without the `FormItemArgs` _(IMO.)_

This adds a `.valid` property and a `.SetValidateFunc` to each of `InputField`, `PasswordField`, `DropDown` and `Checkbox` structs.  

It also adds a `ValidatePrimitive(Primitive,EventKey)` method to `Application` and calls that method inside `<application>.Run()` just before invoking the primitive's `InputHandler()`.

It will only call the validation callback when `event.Key()` is one of
`tcell.KeyEnter`, `tcell.KeyTab`, `tcell.KeyBacktab` or `tcell.KeyEscape`.

If the callback returns `false`, it bypasses the input handler and keeps focus on the just now invalidated field.

Please consider accepting this update.