### PR TITLE
Don't throw away nodes after drawing

### DIFF
--- a/treeview.go
+++ b/treeview.go
@@ -562,13 +562,7 @@ func (t *TreeView) Draw(screen tcell.Screen) {
 		return
 	}
 
-	// Build the tree if necessary.
-	if t.nodes == nil {
-		t.process()
-	}
-	defer func() {
-		t.nodes = nil // Rebuild during next call to Draw()
-	}()
+	t.process()
 
 	// Scroll the tree.
 	x, y, width, height := t.GetInnerRect()


### PR DESCRIPTION
Currently, a tree's nodes are thrown away after drawing a `TreeView`, and then reprocessed on every Draw. This causes `GetRowCount` to always return 0 from the `TreeView`. This PR fixes that problem by simply preserving the nodes between draws.