### PR TITLE
Use Lock to Clear() TextView

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -365,6 +365,8 @@ func (t *TextView) GetScrollOffset() (row, column int) {
 
 // Clear removes all text from the buffer.
 func (t *TextView) Clear() *TextView {
+	t.Lock()
+	defer t.Unlock()
 	t.buffer = nil
 	t.recentBytes = nil
 	t.index = nil


### PR DESCRIPTION
Currently it's possible to call `Clear()` on a TextView while it is currently `Draw()`ing.
This would result in the view having an empty buffer when it is iterating through the
lines on line 839:

`text := t.buffer[index.Line][index.Pos:index.NextPos]`

This will then cause a panic and crash the whole program.

Since `Draw()` already locks, making sure that `Clear()` also does will prevent
the buffer from disappearing in the middle of a draw.