### PR TITLE
Sets flex size to 0 when all items have proportion 0. Fixes: #332

### DIFF
--- a/flex.go
+++ b/flex.go
@@ -149,7 +149,15 @@ func (f *Flex) Draw(screen tcell.Screen) {
 	for _, item := range f.items {
 		size := item.FixedSize
 		if size <= 0 {
-			size = distSize * item.Proportion / proportionSum
+			if proportionSum > 0 {
+				// Proportion sum must be greater than zero, to avoid
+				// integer division error.
+				// This might happen if all items have proportion zero.
+				size = distSize * item.Proportion / proportionSum
+			} else {
+				// If all items had proportion zero, then the size is zero.
+				size = 0
+			}
 			distSize -= size
 			proportionSum -= item.Proportion
 		}


### PR DESCRIPTION
In the rare case when all items have proportion 0, then the size of the
flex is also zero.

I've added a check for `proprtionSum` to be greater than zero to avoid the cases when the sum is zero and a division error is raised.

This fixes #332.