### PR TITLE
Don't skip regions at end of line

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -662,7 +662,7 @@ func (t *TextView) reindexBuffer(width int) {
 				}
 
 				// Is the next tag in range?
-				if tagIndex < 0 || minPos >= tagEnd+remainingLength {
+				if tagIndex < 0 || minPos >= tagEnd+remainingLength+1 {
 					break // No. We're done with this line.
 				}
 


### PR DESCRIPTION
Currently if a region is the last thing on a line, it is skipped. eg. if the "highlight" region is highlighted, the entire text below will be highlighted even though it should have ended at the next region:

```
["highlight"]Test[""]

This is highlighted too.
```

This fixes an off-by-one issue that appears to have been causing the problem.