### PR TITLE
Add escaping text transformer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591
 	github.com/lucasb-eyer/go-colorful v1.0.3
 	github.com/mattn/go-runewidth v0.0.9
+	github.com/mpvl/textutil v0.1.0
 	github.com/rivo/uniseg v0.1.0
 	golang.org/x/sys v0.0.0-20201017003518-b09fb700fbb7 // indirect
-	golang.org/x/text v0.3.3 // indirect
+	golang.org/x/text v0.3.3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
-github.com/gdamore/tcell/v2 v2.0.0 h1:GRWG8aLfWAlekj9Q6W29bVvkHENc6hp79XOqG4AWDOs=
-github.com/gdamore/tcell/v2 v2.0.0/go.mod h1:vSVL/GV5mCSlPC6thFP5kfOFdM9MGZcalipmpTxTgQA=
 github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591 h1:0WWUDZ1oxq7NxVyGo8M3KI5jbkiwNAdZFFzAdC68up4=
 github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591/go.mod h1:vSVL/GV5mCSlPC6thFP5kfOFdM9MGZcalipmpTxTgQA=
 github.com/lucasb-eyer/go-colorful v1.0.3 h1:QIbQXiugsb+q10B+MI+7DI1oQLdmnep86tWFlaaUAac=
@@ -9,13 +7,13 @@ github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mpvl/textutil v0.1.0 h1:XwAj22XZWyOXHYLp9X+xoAzcfojXPLZNxZQufY/8xAc=
+github.com/mpvl/textutil v0.1.0/go.mod h1:SGXTtSzDfdtvEA9zS7HFG/StKT30ko2p1UFLEkv2xOI=
 github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756 h1:9nuHUbU8dRnRRfj9KjWUVrJeoexdbeMjttk6Oh1rD10=
 golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201017003518-b09fb700fbb7 h1:XtNJkfEjb4zR3q20BBBcYUykVOEMgZeIUOpBPfNYgxg=
 golang.org/x/sys v0.0.0-20201017003518-b09fb700fbb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
In an application I am populating a text view that uses colors from a file and do not want to buffer the entire file in memory multiple times or wait for the regexp to run over the entire file (which needs to be escaped to ensure that the user cannot inject colors or regions into the view).
Since text views are writers and the file is being copied in, I needed a wrapper that could wrap the writer and perform the escaping on the entire file as it was copied. A very nice API for dealing with text transformations like this already exists in the [`golang.org/x/text/transform`](https://godoc.org/golang.org/x/text/transform) package, including a way to apply the transformer to a writer. I originally wrote this for my package, but thought it might be useful for others as well and decided to submit it here.

This patch adds a transformer that can be used to escape text and re-implements the `Escape` function in terms of this transformer (resulting in a roughly 2x speedup on simple benchmarks). To keep the code simple and avoid having to redo all the standard transformer logic, the [`github.com/mpvl/textutil`](https://godoc.org/github.com/mpvl/textutil) package was used. This means there is the potential to remove the dependency on textutil in the future and possibly further increase the speed of the escaper at the cost of lots more boilerplate in this package.

I did not include tests in this PR because on a previous change you told me that you didn't want them, however, the tests that I used to verify that the changes matched the old behavior are below. I would by very happy to include them in the PR if you change your mind about testing.

Thanks for your consideration!

<details>
<summary>Benchmark results</summary>
<pre>
$ go test -v -bench . -benchmem
=== RUN   TestEscape
=== RUN   TestEscape/0
=== RUN   TestEscape/0/Legacy
=== RUN   TestEscape/0/Transform
=== RUN   TestEscape/1
=== RUN   TestEscape/1/Legacy
=== RUN   TestEscape/1/Transform
=== RUN   TestEscape/2
=== RUN   TestEscape/2/Legacy
=== RUN   TestEscape/2/Transform
=== RUN   TestEscape/3
=== RUN   TestEscape/3/Legacy
=== RUN   TestEscape/3/Transform
=== RUN   TestEscape/4
=== RUN   TestEscape/4/Legacy
=== RUN   TestEscape/4/Transform
--- PASS: TestEscape (0.00s)
    --- PASS: TestEscape/0 (0.00s)
        --- PASS: TestEscape/0/Legacy (0.00s)
        --- PASS: TestEscape/0/Transform (0.00s)
    --- PASS: TestEscape/1 (0.00s)
        --- PASS: TestEscape/1/Legacy (0.00s)
        --- PASS: TestEscape/1/Transform (0.00s)
    --- PASS: TestEscape/2 (0.00s)
        --- PASS: TestEscape/2/Legacy (0.00s)
        --- PASS: TestEscape/2/Transform (0.00s)
    --- PASS: TestEscape/3 (0.00s)
        --- PASS: TestEscape/3/Legacy (0.00s)
        --- PASS: TestEscape/3/Transform (0.00s)
    --- PASS: TestEscape/4 (0.00s)
        --- PASS: TestEscape/4/Legacy (0.00s)
        --- PASS: TestEscape/4/Transform (0.00s)
goos: linux
goarch: amd64
pkg: github.com/rivo/tview
BenchmarkLegacy-8         397126              2676 ns/op             379 B/op         12 allocs/op
BenchmarkEscape-8         825540              1352 ns/op             434 B/op          5 allocs/op
BenchmarkTransform-8      887028              1240 ns/op             304 B/op          2 allocs/op
PASS
ok      github.com/rivo/tview   3.345s
</pre>
</details>

<details>
<summary>escape_test.go</summary>

```go
package tview_test

import (
	"regexp"
	"strconv"
	"testing"

	"github.com/rivo/tview"
	"golang.org/x/text/transform"
)

var nonEscapePattern = regexp.MustCompile(`(\[[a-zA-Z0-9_,;: \-\."#]+\[*)\]`)

func legacyEscape(text string) string {
	return nonEscapePattern.ReplaceAllString(text, "$1[]")
}

var escapeTests = [...]struct {
	in, out string
}{
	0: {},
	1: {in: `["abc"][""][][red]`, out: `["abc"[][""[][][red[]`},
	2: {in: `[""[[[]`, out: `[""[[[[]`},
	3: {in: `["a[bc"]`, out: `["a[bc"[]`},
	4: {in: `["a]bc"]`, out: `["a[]bc"]`},
}

func TestEscape(t *testing.T) {
	for i, tc := range escapeTests {
		t.Run(strconv.Itoa(i), func(t *testing.T) {
			t.Run("Legacy", func(t *testing.T) {
				out := legacyEscape(tc.in)
				if out != tc.out {
					t.Errorf("want=`%s`, got=`%s`", tc.out, out)
				}
			})
			t.Run("Transform", func(t *testing.T) {
				et := tview.EscapeTransformer()
				out, _, err := transform.String(et, tc.in)
				if err != nil {
					t.Errorf("Unexpected error: %v", err)
				}
				if out != tc.out {
					t.Errorf("want=`%s`, got=`%s`", tc.out, out)
				}
			})
		})
	}
}

const benchEscape = `["abc"][""][][red][""[[[]["a[bc"]["a]bc"]`

func BenchmarkLegacy(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = legacyEscape(benchEscape)
	}
}

func BenchmarkEscape(b *testing.B) {
	for i := 0; i < b.N; i++ {
		_ = tview.Escape(benchEscape)
	}
}

func BenchmarkTransform(b *testing.B) {
	t := tview.EscapeTransformer()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_, _, _ = transform.String(t, benchEscape)
	}
}
```

</details>