### PR TITLE
Feat: allow to override key bindings for tree actions

### DIFF
--- a/demos/treeview/main.go
+++ b/demos/treeview/main.go
@@ -56,6 +56,11 @@ func main() {
 		}
 	})
 
+	// Example of overriding a key binding to select a tree node by pressing G
+	tree.SetKeyBinding(tview.TreeSelectNode, 'G')
+	// Example of overriding a key binding to move up by pressing "up" or "left"
+	tree.SetKeyBinding(tview.TreeMoveUp, rune(tcell.KeyUp), rune(tcell.KeyLeft))
+
 	if err := tview.NewApplication().SetRoot(tree, true).Run(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Previous behaviour
The `treeview` provides some statically hardcoded key bindings for interacting with the tree. The consumers of the package are not able to re-define those bindings.

## New behaviour
The `treeview` reads the key bindings from a configurable map. 
There is a default map of keys to actions, initialised for each new `TreeView`.
However it's possible to redefine key bindings for each action, using method `SetKeyBinding`

## Benefits
I want to be able to reassign the default key bindings and implement some custom tree actions for some keys which currently taken by treeview.