### PR TITLE
Handle ansi code 39 and 49

### DIFF
--- a/ansi.go
+++ b/ansi.go
@@ -145,9 +145,13 @@ func (a *ansi) Write(text []byte) (int, error) {
 						case "30", "31", "32", "33", "34", "35", "36", "37":
 							colorNumber, _ := strconv.Atoi(field)
 							foreground = lookupColor(colorNumber-30, false)
+						case "39":
+							foreground = "default"
 						case "40", "41", "42", "43", "44", "45", "46", "47":
 							colorNumber, _ := strconv.Atoi(field)
 							background = lookupColor(colorNumber-40, false)
+						case "49":
+							background = "default"
 						case "90", "91", "92", "93", "94", "95", "96", "97":
 							colorNumber, _ := strconv.Atoi(field)
 							foreground = lookupColor(colorNumber-90, true)


### PR DESCRIPTION
39 is apparently the "default foreground color"
49 is apparently the "default background color"

Without change:

<img width="183" alt="Screen Shot 2019-09-13 at 8 19 07 PM" src="https://user-images.githubusercontent.com/1523955/64901130-fad6d380-d663-11e9-81c1-b1ab6f083537.png">

With change:

<img width="197" alt="Screen Shot 2019-09-13 at 8 14 47 PM" src="https://user-images.githubusercontent.com/1523955/64901131-ff02f100-d663-11e9-82bf-40e13ad4a600.png">


