### PR TITLE
Table.SetFixedColumnsWidth():  keep columns width fixed when scrolling

### DIFF
--- a/demos/table/main.go
+++ b/demos/table/main.go
@@ -11,6 +11,7 @@ import (
 func main() {
 	app := tview.NewApplication()
 	table := tview.NewTable().
+		SetFixedColumnsWidth(true).
 		SetBorders(true)
 	lorem := strings.Split("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.", " ")
 	cols, rows := 10, 40


### PR DESCRIPTION
Added a new method to Table, SetFixedWidth(), to calculate the maximum width of every column and maintaining it fixed, even if the displayed rows have smaller widths.

This will prevent the tables from changing columns width when scrolling.

This fixes issue #345 