### PR TITLE
Added CustomKeys support in TextView

### DIFF
--- a/demos/textview/main.go
+++ b/demos/textview/main.go
@@ -21,13 +21,15 @@ Capitalize on low hanging fruit to identify a ballpark value added activity to b
 
 func main() {
 	app := tview.NewApplication()
+	customKeys := []tcell.Key{tcell.KeyF1}
 	textView := tview.NewTextView().
 		SetDynamicColors(true).
 		SetRegions(true).
 		SetWordWrap(true).
 		SetChangedFunc(func() {
 			app.Draw()
-		})
+		}).
+		SetCustomKeys(customKeys)
 	numSelections := 0
 	go func() {
 		for _, word := range strings.Split(corporate, " ") {
@@ -50,6 +52,8 @@ func main() {
 			} else {
 				textView.Highlight("0").ScrollToHighlight()
 			}
+		} else if key == tcell.KeyF1 {
+			textView.Highlight("2").ScrollToHighlight()
 		} else if len(currentSelection) > 0 {
 			index, _ := strconv.Atoi(currentSelection[0])
 			if key == tcell.KeyTab {

--- a/textview.go
+++ b/textview.go
@@ -163,6 +163,11 @@ type TextView struct {
 	// highlight(s) into the visible screen.
 	scrollToHighlights bool
 
+	// An optinal value which will give the feature for the developer to pass
+	// the keys they wan't to handle on done func. This can be used to override
+	// the defaults used inside the textView
+	customKeys []tcell.Key
+
 	// An optional function which is called when the content of the text view has
 	// changed.
 	changed func()
@@ -293,6 +298,13 @@ func (t *TextView) SetRegions(regions bool) *TextView {
 		t.index = nil
 	}
 	t.regions = regions
+	return t
+}
+
+//SetCustomKeys sets the key that allows to call done function on these keys
+// along with the default keys
+func (t *TextView) SetCustomKeys(customKeys []tcell.Key) *TextView {
+	t.customKeys = customKeys
 	return t
 }
 
@@ -963,7 +975,7 @@ func (t *TextView) InputHandler() func(event *tcell.EventKey, setFocus func(p Pr
 	return t.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
 		key := event.Key()
 
-		if key == tcell.KeyEscape || key == tcell.KeyEnter || key == tcell.KeyTab || key == tcell.KeyBacktab {
+		if key == tcell.KeyEscape || key == tcell.KeyEnter || key == tcell.KeyTab || key == tcell.KeyBacktab || Contains(t.customKeys, key) {
 			if t.done != nil {
 				t.done(key)
 			}

--- a/util.go
+++ b/util.go
@@ -624,3 +624,12 @@ func iterateStringReverse(text string, callback func(main rune, comb []rune, tex
 
 	return false
 }
+
+func Contains(keys []tcell.Key, key tcell.Key) bool {
+	for _, elem := range keys {
+		if elem == key {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
In Current implementation, InputHandler function it is hardcoded when to call function `done` which is defined by user. In new implementation added a key customKeys to
TextView which can be set by passing `[]tcell.Key` and handle them inside
user defined function `done`.

Later we can remove the other three functions and make it completely user defined keys.