### PR TITLE
Added SetFocus to Modal. Resolves #360

### DIFF
--- a/modal.go
+++ b/modal.go
@@ -126,6 +126,14 @@ func (m *Modal) ClearButtons() *Modal {
 	return m
 }
 
+// SetFocus shifts the focus to the form element with the given index, counting
+// non-button items first and buttons last. Note that this index is only used
+// when the form itself receives focus.
+func (m *Modal) SetFocus(index int) *Modal {
+	m.form.SetFocus(index)
+	return m
+}
+
 // Focus is called when this primitive receives focus.
 func (m *Modal) Focus(delegate func(p Primitive)) {
 	delegate(m.form)


### PR DESCRIPTION
This is a simple function to call the underlying form.SetFocus function in a modal dialog. This would resolve issue #360 and allows the selected model button to be set.