### PR TITLE
Add support for displaying text next to a checkbox

### DIFF
--- a/checkbox.go
+++ b/checkbox.go
@@ -17,6 +17,9 @@ type Checkbox struct {
 	// The text to be displayed before the input area.
 	label string
 
+	// The text to be displayed after the checkbox
+	message string
+
 	// The screen width of the label area. A value of 0 means use the width of
 	// the label text.
 	labelWidth int
@@ -76,6 +79,17 @@ func (c *Checkbox) GetLabel() string {
 	return c.label
 }
 
+// SetMessage sets the text to be displayed after the checkbox
+func (c *Checkbox) SetMessage(message string) *Checkbox {
+	c.message = message
+	return c
+}
+
+// GetMessage returns the text to be displayed after the checkbox
+func (c *Checkbox) GetMessage() string {
+	return c.message
+}
+
 // SetLabelWidth sets the screen width of the label. A value of 0 will cause the
 // primitive to use the width of the label string.
 func (c *Checkbox) SetLabelWidth(width int) *Checkbox {
@@ -113,7 +127,11 @@ func (c *Checkbox) SetFormAttributes(labelWidth int, labelColor, bgColor, fieldT
 
 // GetFieldWidth returns this primitive's field width.
 func (c *Checkbox) GetFieldWidth() int {
-	return 1
+	if c.message == "" {
+		return 1
+	} else {
+		return 2 + len(c.message)
+	}
 }
 
 // SetChangedFunc sets a handler which is called when the checked state of this
@@ -176,6 +194,10 @@ func (c *Checkbox) Draw(screen tcell.Screen) {
 		checkedRune = ' '
 	}
 	screen.SetContent(x, y, checkedRune, nil, fieldStyle)
+
+	if c.message != "" {
+		Print(screen, c.message, x+2, y, len(c.message), AlignLeft, c.labelColor)
+	}
 }
 
 // InputHandler returns the handler for this primitive.


### PR DESCRIPTION
When building forms the label field is typically quite short, just one
or two words. For checkboxes it is often desirable to have a longer
descriptive piece of text. This is not practical to use as a label and
in many applications would more commonly be placed to the right of the
checkbox.

This adds support for a "SetMessage()" method which provides support
for text adjacent to the checkbox

As an example, this form shows one usage pattern, where the checkbox
is used to require case sensitive matching of the author name query.
In this case the checkbox label is an empty string, and the message
text is used instead:

```
 ╔════════════ User filtering ════════════════════╗
 ║                                                ║
 ║    Age:   ________                             ║
 ║                                                ║
 ║ Author:   ______________                       ║
 ║                                                ║
 ║           X Case sensitive                     ║
 ║                                                ║
 ║   Apply     Cancel                             ║
 ╚════════════════════════════════════════════════╝
```

Another pattern is where there are a series of checkboxes, all
related to the same attribute. Thus they have a common form
label but different message text

```
 ╔════════════ Request filtering ═════════════════╗
 ║                                                ║
 ║    State:    X Opened                          ║
 ║                                                ║
 ║              _ Closed                          ║
 ║                                                ║
 ║              _ Merged                          ║
 ║                                                ║
 ║              X Locked                          ║
 ║                                                ║
 ║   Apply     Cancel                             ║
 ╚════════════════════════════════════════════════╝
```

Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>