### PR TITLE
Throttle resize handling. Fixes #377

### DIFF
--- a/application.go
+++ b/application.go
@@ -2,6 +2,7 @@ package tview
 
 import (
 	"sync"
+	"time"
 
 	"github.com/gdamore/tcell"
 )
@@ -125,6 +126,8 @@ func (a *Application) SetScreen(screen tcell.Screen) *Application {
 // when Stop() was called.
 func (a *Application) Run() error {
 	var err error
+	var redrawTimer *time.Timer
+
 	a.Lock()
 
 	// Make a screen if there is none yet.
@@ -244,8 +247,14 @@ EventLoop:
 				if screen == nil {
 					continue
 				}
-				screen.Clear()
-				a.draw()
+				//throttle event size handling to once/500ms in order to mitigate screen flashing 
+				if(redrawTimer != nil) {
+					redrawTimer.Stop()
+				}
+				redrawTimer = time.AfterFunc(0.5*1000000000/*convert seconds to nanoseconds*/, func() {
+					screen.Clear()
+					a.draw()
+				})
 			}
 
 		// If we have updates, now is the time to execute them.

--- a/application.go
+++ b/application.go
@@ -247,11 +247,12 @@ EventLoop:
 				if screen == nil {
 					continue
 				}
-				//throttle event size handling to once/500ms in order to mitigate screen flashing 
+
+				// Throttle event resize handling in order to mitigate screen flashing
 				if(redrawTimer != nil) {
 					redrawTimer.Stop()
 				}
-				redrawTimer = time.AfterFunc(0.5*1000000000/*convert seconds to nanoseconds*/, func() {
+				redrawTimer = time.AfterFunc(200*time.Millisecond, func() {
 					screen.Clear()
 					a.draw()
 				})


### PR DESCRIPTION
This fixes #377
Sorry for any obvious mistakes; I am a golang novice.
I read over the contribution guidelines and tried to match the style.
I don't believe this is adding significant maintenance overhead.

The objective is to add some throttling to the resize handling so that the screen does not flash on Windows.  I fiddled with the throttling a bit and 200ms seems like the sweet spot between too low (resulting in allowing some flashing) and too high (too slow resize redraw makes it seem laggy).  Here is capture of the post-fix behavior:
![after fix](https://user-images.githubusercontent.com/513830/70583677-520d1700-1b73-11ea-86a3-1c2c085dc00f.gif)

Compare with the capture of before-fix behavior:
![before fix](https://user-images.githubusercontent.com/513830/70582356-1f611f80-1b6f-11ea-95e7-7720a2ee299b.gif)


Thanks in advance for taking the time to review!