### PR TITLE
Fix presentation demo appending TextView indefinitely

### DIFF
--- a/demos/presentation/textview.go
+++ b/demos/presentation/textview.go
@@ -46,6 +46,11 @@ func TextView1(nextSlide func()) (title string, content tview.Primitive) {
 		var n int
 		for {
 			n++
+			if n > 512 {
+				n = 1
+				textView.SetText("")
+			}
+
 			fmt.Fprintf(textView, "%d ", n)
 			time.Sleep(200 * time.Millisecond)
 		}


### PR DESCRIPTION
This fixes the unbounded increase in resource usage when running the presentation demo.