### PR TITLE
Add Flex.Clear() method to remove all items in flexbox

### DIFF
--- a/flex.go
+++ b/flex.go
@@ -101,7 +101,7 @@ func (f *Flex) RemoveItem(p Primitive) *Flex {
 	return f
 }
 
-// Clear removes all items from the flexbox
+// Clear removes all items from the container.
 func (f *Flex) Clear() *Flex {
 	f.items = nil
 	return f

--- a/flex.go
+++ b/flex.go
@@ -101,6 +101,12 @@ func (f *Flex) RemoveItem(p Primitive) *Flex {
 	return f
 }
 
+// Clear removes all items from the flexbox
+func (f *Flex) Clear() *Flex {
+	f.items = nil
+	return f
+}
+
 // ResizeItem sets a new size for the item(s) with the given primitive. If there
 // are multiple Flex items with the same primitive, they will all receive the
 // same size. For details regarding the size parameters, see AddItem().


### PR DESCRIPTION
Other components that contain a list of items have a `Clear()` method to remove them all.
E.g:
* [Grid.Clear()](https://godoc.org/github.com/rivo/tview#Grid.Clear)
* [List.Clear()](https://godoc.org/github.com/rivo/tview#List.Clear)
* [Table.Clear()](https://godoc.org/github.com/rivo/tview#Table.Clear)

This PR adds the same `Clear()` method to the Flex component.