### PR TITLE
Fix horizontal scrolling text with wide characters in TexView widget

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -925,6 +925,9 @@ func (t *TextView) Draw(screen tcell.Screen) {
 				// Skip to the right.
 				if !t.wrap && skipped < skip {
 					skipped += screenWidth
+					if skipped > skip {
+						posX += skipped - skip
+					}
 					return false
 				}
 


### PR DESCRIPTION
Fixes scrolling lines with double with characters. Example, where the problem occurs without this fix:
```
package main

import (
	"github.com/rivo/tview"
)

func main() {
	app := tview.NewApplication()
	t := tview.NewTextView().SetWrap(false)

	t.SetText("line 1 😀😀 q w e r t y a b c\nline 2 ---- q w e r t y a b c")

	if err := app.SetRoot(t, false).SetFocus(t).Run(); err != nil {
		panic(err)
	}
}
```
Maybe a special character should be added instead of invisible half of double with character? Because now they are disappearing at the edges. Like this `⋯ ` (though vim and nano use `>`).