### PR TITLE
Allow changing current node and changing focus in treeview handlers

### DIFF
--- a/treeview.go
+++ b/treeview.go
@@ -747,13 +747,14 @@ func (t *TreeView) MouseHandler() func(action MouseAction, event *tcell.EventMou
 			if y >= 0 && y < len(t.nodes) {
 				node := t.nodes[y]
 				if node.selectable {
-					if t.currentNode != node && t.changed != nil {
+					previousNode := t.currentNode
+					t.currentNode = node
+					if previousNode != node && t.changed != nil {
 						t.changed(node)
 					}
 					if t.selected != nil {
 						t.selected(node)
 					}
-					t.currentNode = node
 				}
 			}
 			consumed = true

--- a/treeview.go
+++ b/treeview.go
@@ -756,6 +756,9 @@ func (t *TreeView) MouseHandler() func(action MouseAction, event *tcell.EventMou
 					if t.selected != nil {
 						t.selected(node)
 					}
+					if node.selected != nil {
+						node.selected()
+					}
 				}
 			}
 			consumed = true

--- a/treeview.go
+++ b/treeview.go
@@ -681,12 +681,13 @@ func (t *TreeView) Draw(screen tcell.Screen) {
 func (t *TreeView) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
 	return t.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
 		selectNode := func() {
-			if t.currentNode != nil {
+			node := t.currentNode
+			if node != nil {
 				if t.selected != nil {
-					t.selected(t.currentNode)
+					t.selected(node)
 				}
-				if t.currentNode.selected != nil {
-					t.currentNode.selected()
+				if node.selected != nil {
+					node.selected()
 				}
 			}
 		}

--- a/treeview.go
+++ b/treeview.go
@@ -742,6 +742,7 @@ func (t *TreeView) MouseHandler() func(action MouseAction, event *tcell.EventMou
 
 		switch action {
 		case MouseLeftClick:
+			setFocus(t)
 			_, rectY, _, _ := t.GetInnerRect()
 			y -= rectY
 			if y >= 0 && y < len(t.nodes) {
@@ -758,7 +759,6 @@ func (t *TreeView) MouseHandler() func(action MouseAction, event *tcell.EventMou
 				}
 			}
 			consumed = true
-			setFocus(t)
 		case MouseScrollUp:
 			t.movement = treeUp
 			consumed = true


### PR DESCRIPTION
Without this, SetCurrentNode(nil) in a handler is either ignored or panics on nil.
Also I'd like to change focus on selected.