### PR TITLE
Replace spacePattern in TextView word wrapping with strings.TrimRightFunc

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/gdamore/tcell"
@@ -821,10 +822,11 @@ func (t *TextView) reindexBuffer(width int) {
 		if t.wrap && t.wordWrap {
 			for _, line := range t.index {
 				str := t.buffer[line.Line][line.Pos:line.NextPos]
-				spaces := spacePattern.FindAllStringIndex(str, -1)
-				if spaces != nil && spaces[len(spaces)-1][1] == len(str) {
+				trimmed := strings.TrimRightFunc(str, unicode.IsSpace)
+
+				if len(trimmed) != len(str) {
 					oldNextPos := line.NextPos
-					line.NextPos -= spaces[len(spaces)-1][1] - spaces[len(spaces)-1][0]
+					line.NextPos -= len(str) - len(trimmed)
 					line.Width -= stringWidth(t.buffer[line.Line][line.NextPos:oldNextPos])
 				}
 			}


### PR DESCRIPTION
Old code using regular expression does a lot of unnecessary work.

<details>
<summary>Benchmarks from #356 with significant difference</summary>

```
benchmark                                                                      old ns/op     new ns/op     delta
[...]
BenchmarkTextViewDraw/App=T/Color=F/Region=F/Scroll=T/Wrap=T/WordWrap=T-4      1890452       405316        -78.56%
[...]
BenchmarkTextViewDraw/App=T/Color=F/Region=T/Scroll=T/Wrap=T/WordWrap=T-4      2202032       432266        -80.37%
[...]
BenchmarkTextViewDraw/App=T/Color=T/Region=F/Scroll=T/Wrap=T/WordWrap=T-4      2210060       434488        -80.34%
[...]
BenchmarkTextViewDraw/App=T/Color=T/Region=T/Scroll=T/Wrap=T/WordWrap=T-4      2260540       447661        -80.20%

benchmark                                                                      old allocs     new allocs     delta
[...]
BenchmarkTextViewDraw/App=T/Color=F/Region=F/Scroll=T/Wrap=T/WordWrap=T-4      1712           659            -61.51%
[...]
BenchmarkTextViewDraw/App=T/Color=F/Region=T/Scroll=T/Wrap=T/WordWrap=T-4      1949           698            -64.19%
[...]
BenchmarkTextViewDraw/App=T/Color=T/Region=F/Scroll=T/Wrap=T/WordWrap=T-4      1955           698            -64.30%
[...]
BenchmarkTextViewDraw/App=T/Color=T/Region=T/Scroll=T/Wrap=T/WordWrap=T-4      1991           709            -64.39%

benchmark                                                                      old bytes     new bytes     delta
[...]
BenchmarkTextViewDraw/App=T/Color=F/Region=F/Scroll=T/Wrap=T/WordWrap=T-4      145969        23404         -83.97%
[...]
BenchmarkTextViewDraw/App=T/Color=F/Region=T/Scroll=T/Wrap=T/WordWrap=T-4      170502        24437         -85.67%
[...]
BenchmarkTextViewDraw/App=T/Color=T/Region=F/Scroll=T/Wrap=T/WordWrap=T-4      170905        24448         -85.69%
[...]
BenchmarkTextViewDraw/App=T/Color=T/Region=T/Scroll=T/Wrap=T/WordWrap=T-4      174575        24921         -85.72%
```

</details>

[All benchmarks results](https://github.com/rivo/tview/files/4528321/benchcmp.txt)