### PR TITLE
Fixed terminal colors

### DIFF
--- a/ansi.go
+++ b/ansi.go
@@ -141,20 +141,20 @@ func (a *ansi) Write(text []byte) (int, error) {
 							clearAttributes = true
 						case "30", "31", "32", "33", "34", "35", "36", "37":
 							colorNumber, _ := strconv.Atoi(field)
-							foreground = lookupColor(colorNumber-30)
+							foreground = lookupColor(colorNumber - 30)
 						case "39":
 							foreground = "-"
 						case "40", "41", "42", "43", "44", "45", "46", "47":
 							colorNumber, _ := strconv.Atoi(field)
-							background = lookupColor(colorNumber-40)
+							background = lookupColor(colorNumber - 40)
 						case "49":
 							background = "-"
 						case "90", "91", "92", "93", "94", "95", "96", "97":
 							colorNumber, _ := strconv.Atoi(field)
-							foreground = lookupColor(colorNumber-82)
+							foreground = lookupColor(colorNumber - 82)
 						case "100", "101", "102", "103", "104", "105", "106", "107":
 							colorNumber, _ := strconv.Atoi(field)
-							background = lookupColor(colorNumber-92)
+							background = lookupColor(colorNumber - 92)
 						case "38", "48":
 							var color string
 							if len(fields) > index+1 {

--- a/ansi.go
+++ b/ansi.go
@@ -110,21 +110,21 @@ func (a *ansi) Write(text []byte) (int, error) {
 						}
 						return [...]string{
 							"black",
-							"red",
+							"maroon",
 							"green",
+							"olive",
+							"navy",
+							"purple",
+							"teal",
+							"silver",
+							"gray",
+							"red",
+							"lime",
 							"yellow",
 							"blue",
-							"darkmagenta",
-							"darkcyan",
+							"fuchsia",
+							"aqua",
 							"white",
-							"#7f7f7f",
-							"#ff0000",
-							"#00ff00",
-							"#ffff00",
-							"#5c5cff",
-							"#ff00ff",
-							"#00ffff",
-							"#ffffff",
 						}[colorNumber]
 					}
 				FieldLoop:

--- a/ansi.go
+++ b/ansi.go
@@ -101,14 +101,11 @@ func (a *ansi) Write(text []byte) (int, error) {
 						}
 						break
 					}
-					lookupColor := func(colorNumber int, bright bool) string {
-						if colorNumber < 0 || colorNumber > 7 {
+					lookupColor := func(colorNumber int) string {
+						if colorNumber < 0 || colorNumber > 15 {
 							return "black"
 						}
-						if bright {
-							colorNumber += 8
-						}
-						return [...]string{
+						return []string{
 							"black",
 							"maroon",
 							"green",
@@ -144,29 +141,27 @@ func (a *ansi) Write(text []byte) (int, error) {
 							clearAttributes = true
 						case "30", "31", "32", "33", "34", "35", "36", "37":
 							colorNumber, _ := strconv.Atoi(field)
-							foreground = lookupColor(colorNumber-30, false)
+							foreground = lookupColor(colorNumber-30)
 						case "39":
 							foreground = "-"
 						case "40", "41", "42", "43", "44", "45", "46", "47":
 							colorNumber, _ := strconv.Atoi(field)
-							background = lookupColor(colorNumber-40, false)
+							background = lookupColor(colorNumber-40)
 						case "49":
 							background = "-"
 						case "90", "91", "92", "93", "94", "95", "96", "97":
 							colorNumber, _ := strconv.Atoi(field)
-							foreground = lookupColor(colorNumber-90, true)
+							foreground = lookupColor(colorNumber-82)
 						case "100", "101", "102", "103", "104", "105", "106", "107":
 							colorNumber, _ := strconv.Atoi(field)
-							background = lookupColor(colorNumber-100, true)
+							background = lookupColor(colorNumber-92)
 						case "38", "48":
 							var color string
 							if len(fields) > index+1 {
 								if fields[index+1] == "5" && len(fields) > index+2 { // 8-bit colors.
 									colorNumber, _ := strconv.Atoi(fields[index+2])
-									if colorNumber <= 7 {
-										color = lookupColor(colorNumber, false)
-									} else if colorNumber <= 15 {
-										color = lookupColor(colorNumber, true)
+									if colorNumber <= 15 {
+										color = lookupColor(colorNumber)
 									} else if colorNumber <= 231 {
 										red := (colorNumber - 16) / 36
 										green := ((colorNumber - 16) / 6) % 6


### PR DESCRIPTION
I was noticing some very weird issues related to color. I tracked it down to this color slice. I grabbed the color names from tcell, so hopefully colors 000-015 are acceptable now.

It wasn't completely noticeable with the Tango colorscheme:

![tango_before_and_after](https://user-images.githubusercontent.com/1239825/81633892-bf9bc880-93db-11ea-925f-a718c503dde7.png)

But was much more noticeable with the Solarized Dark colorscheme:

![solarizeddark_before_and_after](https://user-images.githubusercontent.com/1239825/81633933-d80be300-93db-11ea-946d-19b296f0cdbc.png)

This should fix #445. 