### PR TITLE
TextView: Add SetMaxLines()

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -140,6 +140,9 @@ type TextView struct {
 	// The index of the first line shown in the text view.
 	lineOffset int
 
+	// The maximum number of newlines the text view will hold (0 = unlimited)
+	maxLines int
+
 	// If set to true, the text view will always remain at the end of the content.
 	trackEnd bool
 
@@ -205,6 +208,7 @@ func NewTextView() *TextView {
 		textColor:     Styles.PrimaryTextColor,
 		regions:       false,
 		dynamicColors: false,
+		maxLines:      0,
 	}
 }
 
@@ -355,6 +359,25 @@ func (t *TextView) SetDoneFunc(handler func(key tcell.Key)) *TextView {
 // can only fire for regions that have existed during the last call to Draw().
 func (t *TextView) SetHighlightedFunc(handler func(added, removed, remaining []string)) *TextView {
 	t.highlighted = handler
+	return t
+}
+
+func (t *TextView) clipBuffer() {
+	if t.maxLines <= 0 {
+		return
+	}
+
+	lenbuf := len(t.buffer)
+	if lenbuf > t.maxLines {
+		t.buffer = t.buffer[lenbuf-t.maxLines:]
+	}
+}
+
+// SetMaxLines sets the maximum number of newlines the text view will hold
+// before discarding older data from the buffer.
+func (t *TextView) SetMaxLines(maxLines int) *TextView {
+	t.maxLines = maxLines
+	t.clipBuffer()
 	return t
 }
 
@@ -658,6 +681,8 @@ func (t *TextView) Write(p []byte) (n int, err error) {
 			t.buffer = append(t.buffer, line)
 		}
 	}
+
+	t.clipBuffer()
 
 	// Reset the index.
 	t.index = nil

--- a/textview_test.go
+++ b/textview_test.go
@@ -1,0 +1,57 @@
+package tview_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rivo/tview"
+)
+
+func TestTextViewMaxLines(t *testing.T) {
+	tv := tview.NewTextView()
+
+	// append 100 lines with no limit set:
+	for i := 0; i < 100; i++ {
+		_, err := tv.Write([]byte(fmt.Sprintf("L%d\n", i)))
+		if err != nil {
+			t.Errorf("failed to write to TextView: %s", err)
+		}
+	}
+
+	// retrieve the total text and see we have the 100 lines:
+	count := strings.Count(tv.GetText(true), "\n")
+	if count != 100 {
+		t.Errorf("expected 100 lines, got %d", count)
+	}
+
+	// now set the maximum lines to 20, this should clip the buffer:
+	tv.SetMaxLines(20)
+	// verify buffer was clipped:
+	count = len(strings.Split(tv.GetText(true), "\n"))
+	if count != 20 {
+		t.Errorf("expected 20 lines, got %d", count)
+	}
+
+	// append 100 more lines:
+	for i := 100; i < 200; i++ {
+		_, err := tv.Write([]byte(fmt.Sprintf("L%d\n", i)))
+		if err != nil {
+			t.Errorf("failed to write to TextView: %s", err)
+		}
+	}
+
+	// Since max lines is set to 20, we should still get 20 lines:
+	txt := tv.GetText(true)
+	lines := strings.Split(txt, "\n")
+	count = len(lines)
+	if count != 20 {
+		t.Errorf("expected 20 lines, got %d", count)
+	}
+
+	// and those 20 lines should be the last ones:
+	if lines[0] != "L181" {
+		t.Errorf("expected to get L181, got %s", lines[0])
+	}
+
+}


### PR DESCRIPTION
Fixes #451 

This PR implements a new method `TextView.SetMaxLines()` that limits the amount of lines that can be added to a buffer. This is useful to use TextView to show scrolling content, such as log output.

If this method is not used, the default is "no limit", thus this method is backward-compatible and does not affect existing behavior of the TextView