### PR TITLE
Add Modal.GetForm and Modal.GetFrame

### DIFF
--- a/modal.go
+++ b/modal.go
@@ -6,7 +6,8 @@ import (
 
 // Modal is a centered message window used to inform the user or prompt them
 // for an immediate decision. It needs to have at least one button (added via
-// AddButtons()) or it will never disappear.
+// AddButtons()) or it will never disappear. You may embed primitives within a
+// Modal by adding them to the Form returned by GetForm.
 //
 // See https://github.com/rivo/tview/wiki/Modal for an example.
 type Modal struct {
@@ -95,6 +96,16 @@ func (m *Modal) SetText(text string) *Modal {
 	return m
 }
 
+// GetForm returns the form embedded in the window.
+func (m *Modal) GetForm() *Form {
+	return m.form
+}
+
+// GetFrame returns the frame embedded in the window.
+func (m *Modal) GetFrame() *Frame {
+	return m.frame
+}
+
 // AddButtons adds buttons to the window. There must be at least one button and
 // a "done" handler so the window can be closed again.
 func (m *Modal) AddButtons(labels []string) *Modal {
@@ -144,6 +155,8 @@ func (m *Modal) HasFocus() bool {
 
 // Draw draws this primitive onto the screen.
 func (m *Modal) Draw(screen tcell.Screen) {
+	formItemCount := m.form.GetFormItemCount()
+
 	// Calculate the width of this modal.
 	buttonsWidth := 0
 	for _, button := range m.form.buttons {
@@ -165,7 +178,7 @@ func (m *Modal) Draw(screen tcell.Screen) {
 	}
 
 	// Set the modal's position and size.
-	height := len(lines) + 6
+	height := len(lines) + (formItemCount * 2) + 6
 	width += 4
 	x := (screenWidth - width) / 2
 	y := (screenHeight - height) / 2


### PR DESCRIPTION
These changes allow developers to embed primitives within a modal window.

This change is available now in [cview](https://gitlab.com/tslocum/cview), a fork of tview.