### PR TITLE
Fix bug in list RemoveItem

### DIFF
--- a/list.go
+++ b/list.go
@@ -148,9 +148,9 @@ func (l *List) RemoveItem(index int) *List {
 		return l
 	}
 
-	// Shift current item.
+	// Shift current item when it was the last.
 	previousCurrentItem := l.currentItem
-	if l.currentItem >= index {
+	if l.currentItem >= len(l.items) {
 		l.currentItem--
 	}
 


### PR DESCRIPTION
When a changed function is set, deleting the first element (0-index) lead to a index out of range error because the change event was fired with index = -1.
Now the index will only be decreased if the last item was removed. As a side effect that changes the behavior of the selection slightly:
It will stay at the same place and only move up when the last item was removed.