### PR TITLE
Lock until replacement is initialized

### DIFF
--- a/application.go
+++ b/application.go
@@ -282,12 +282,12 @@ func (a *Application) Run() error {
 			// We have a new screen. Keep going.
 			a.Lock()
 			a.screen = screen
-			a.Unlock()
 
 			// Initialize and draw this screen.
 			if err := screen.Init(); err != nil {
 				panic(err)
 			}
+			a.Unlock()
 			a.draw()
 		}
 	}()


### PR DESCRIPTION
I've experienced seemingly random hangs after returning from a suspend. After a lot of debugging, it seems that the issue is due to a call to Application.draw from the event loop before the replacement screen has been fully initialized. This aims to fix that race condition, and it's also how it's done in Application.Run (i.e. lock until screen has been fully initialized).