### PR TITLE
Match box border bg with box bg color

### DIFF
--- a/box.go
+++ b/box.go
@@ -70,7 +70,7 @@ func NewBox() *Box {
 		height:          10,
 		innerX:          -1, // Mark as uninitialized.
 		backgroundColor: Styles.PrimitiveBackgroundColor,
-		borderStyle:     tcell.StyleDefault.Foreground(Styles.BorderColor),
+		borderStyle:     tcell.StyleDefault.Foreground(Styles.BorderColor).Background(Styles.PrimitiveBackgroundColor),
 		titleColor:      Styles.TitleColor,
 		titleAlign:      AlignCenter,
 	}
@@ -252,6 +252,7 @@ func (b *Box) GetMouseCapture() func(action MouseAction, event *tcell.EventMouse
 // SetBackgroundColor sets the box's background color.
 func (b *Box) SetBackgroundColor(color tcell.Color) *Box {
 	b.backgroundColor = color
+	b.borderStyle = b.borderStyle.Background(color)
 	return b
 }
 


### PR DESCRIPTION
fixes https://github.com/rivo/tview/issues/519

Before change:

![presentation_demo](https://user-images.githubusercontent.com/634657/98324529-5f0fd180-1fa1-11eb-8c61-7f1b8cdc4fb5.png)

After change:

![Screen Shot 2020-11-05 at 7 54 42 PM](https://user-images.githubusercontent.com/634657/98324543-6636df80-1fa1-11eb-9920-c359afd4ed59.png)

Notice the background color of the border around each frame box and the modal.

One mystery: if I checkout https://github.com/rivo/tview/commit/53d50e499bf914fbd2873aa7d8b1bcb6427dde0e and run the presentation demo, the modal color is a dark blue.  Unsure why it changes color, maybe something with tcell upgrade?

Unsure if this is the best way to fix this problem, so open to suggestions.  I guess an alternative would be to revert the switch to using the `borderStyle` property?  Cheers!