### PR TITLE
Added ecsview

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For a presentation highlighting this package, compile and run the program found 
 - [Discord, TUI and SIXEL.](https://gitlab.com/diamondburned/6cord)
 - [A CLI Audio Player](https://www.github.com/dhulihan/grump)
 - [GLab, a GitLab CLI tool](https://gitlab.com/profclems/glab)
+- [Browse your AWS ECS Clusters in the Terminal](https://github.com/swartzrock/ecsview)
 
 ## Documentation
 


### PR DESCRIPTION
Hi @rivo I've really enjoyed using tview to build ecsview, a terminal app for browsing AWS ECS clusters in detail. Added ecsview to the list of projects in the README.