### PR TITLE
Fix crashing in textview.go

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -938,7 +938,7 @@ func (t *TextView) Draw(screen tcell.Screen) {
 	defaultStyle := tcell.StyleDefault.Foreground(t.textColor)
 	for line := t.lineOffset; line < len(t.index); line++ {
 		// Are we done?
-		if line-t.lineOffset >= height || y+line-t.lineOffset >= totalHeight {
+		if line-t.lineOffset >= height || y+line-t.lineOffset >= totalHeight || len(t.buffer) == 0 {
 			break
 		}
 


### PR DESCRIPTION
My application has a **textView**, which is being updated very often, for example each millisecond. It sometimes crashes when I try to close a modal window with `app.SetRoot(pages, true)`. I've figured out, that this PR's `t.buffer` is sometimes empty, so I tried to add an additional check and it seems to help. You can choose a more efficient way if such exists. Some time ago I got a similar error at line 826 `str := t.buffer[line.Line][line.Pos:line.NextPos]` - maybe it should be fixed too.

Panic's error:
```
panic: runtime error: index out of range [1] with length 0 [recovered]
	panic: runtime error: index out of range [1] with length 0

goroutine 1 [running]:
github.com/rivo/tview.(*Application).Run.func1(0xc00015e000)
	/path/src/github.com/rivo/tview/application.go:243 +0x87
panic(0x5916e0, 0xc0001b40c0)
	/path/src/runtime/panic.go:969 +0x1b9
github.com/rivo/tview.(*TextView).Draw(0xc000152300, 0x5da440, 0xc0000d6600)
	/path/src/github.com/rivo/tview/textview.go:947 +0xded
github.com/rivo/tview.(*Grid).Draw(0xc000162090, 0x5da440, 0xc0000d6600)
	/path/src/github.com/rivo/tview/grid.go:626 +0x12cf
github.com/rivo/tview.(*Pages).Draw(0xc00009ad80, 0x5da440, 0xc0000d6600)
	/path/src/github.com/rivo/tview/pages.go:277 +0xb9
github.com/rivo/tview.(*Application).draw(0xc00015e000, 0x0)
	/path/src/github.com/rivo/tview/application.go:595 +0xd9
github.com/rivo/tview.(*Application).Run(0xc00015e000, 0x0, 0x0)
	/path/src/github.com/rivo/tview/application.go:343 +0x625
main.main()
	/path/src/github.com/user/myapp/main.go:43 +0x88
exit status 2
```