### PR TITLE
Fix inverted handling of KeyPgDn/KeyPgUp in List widget

### DIFF
--- a/list.go
+++ b/list.go
@@ -572,9 +572,15 @@ func (l *List) InputHandler() func(event *tcell.EventKey, setFocus func(p Primit
 		case tcell.KeyPgDn:
 			_, _, _, height := l.GetInnerRect()
 			l.currentItem += height
+			if l.currentItem >= len(l.items) {
+				l.currentItem = len(l.items) - 1
+			}
 		case tcell.KeyPgUp:
 			_, _, _, height := l.GetInnerRect()
 			l.currentItem -= height
+			if l.currentItem < 0 {
+				l.currentItem = 0
+			}
 		case tcell.KeyEnter:
 			if l.currentItem >= 0 && l.currentItem < len(l.items) {
 				item := l.items[l.currentItem]


### PR DESCRIPTION
Consider a list with 5 items, and the currentItem index is 2, and
all items fit on the screen without scrolling.

KeyPgDn will set currentItem to 7 which is out of bounds, and
gets wrapped around to 0.

KeyPgUp will set currentItem to -3 which is out of bounds, and
gets wrapped around to 4.

Thus PgDn selects the first item, while PgUp selects the last item,
which is the opposite of expected behaviour for these keys. Fix
this by clamping currentItem to the boundaries in the key handler.

Fixes: https://github.com/rivo/tview/issues/580
Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>