### PR TITLE
Allow arrow-left to move to previous line

### DIFF
--- a/table.go
+++ b/table.go
@@ -1156,7 +1156,12 @@ func (t *Table) InputHandler() func(event *tcell.EventKey, setFocus func(p Primi
 				if t.columnsSelectable {
 					t.selectedColumn--
 					if t.selectedColumn < 0 {
-						t.selectedColumn = 0
+						t.selectedColumn = t.lastColumn
+						t.selectedRow--
+						if t.selectedRow < 0 {
+							t.selectedRow = 0
+							t.selectedColumn = 0
+						}
 					}
 					previous()
 				} else {


### PR DESCRIPTION
This PR will enable the table view to move the cursor to the previous line if "arrow-left" is pressed in the first column. Pressing right in the last column is already supported.

Right now a user can press "right arrow" at the rightmost cell in a row and end up in the start of next row - unable to get back by pressing "arrow left". This PR fixes that.