### PR TITLE
Add flag selectedReverseColor to reverse style of selected item

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For a presentation highlighting this package, compile and run the program found 
 - [Fast disk usage analyzer written in Go](https://github.com/dundee/gdu)
 - [Multiplayer Chess On Terminal](https://github.com/qnkhuat/gochess)
 - [Scriptable TUI music player](https://github.com/issadarkthing/gomu)
+- [MangaDesk : TUI Client for downloading manga to your computer](https://github.com/darylhjd/mangadesk)
 
 ## Documentation
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/rivo/tview
 go 1.12
 
 require (
-	github.com/gdamore/tcell/v2 v2.2.1
+	github.com/gdamore/tcell/v2 v2.3.3
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-runewidth v0.0.10
 	github.com/rivo/uniseg v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/gdamore/tcell/v2 v2.2.0 h1:vSyEgKwraXPSOkvCk7IwOSyX+Pv3V2cV9CikJMXg4U
 github.com/gdamore/tcell/v2 v2.2.0/go.mod h1:cTTuF84Dlj/RqmaCIV5p4w8uG1zWdk0SF6oBpwHp4fU=
 github.com/gdamore/tcell/v2 v2.2.1 h1:Gt8wk0jd5pIK2CyXNo/fqwxNWf726j1lQjEDdfbnqTc=
 github.com/gdamore/tcell/v2 v2.2.1/go.mod h1:cTTuF84Dlj/RqmaCIV5p4w8uG1zWdk0SF6oBpwHp4fU=
+github.com/gdamore/tcell/v2 v2.3.3 h1:RKoI6OcqYrr/Do8yHZklecdGzDTJH9ACKdfECbRdw3M=
+github.com/gdamore/tcell/v2 v2.3.3/go.mod h1:cTTuF84Dlj/RqmaCIV5p4w8uG1zWdk0SF6oBpwHp4fU=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=

--- a/list.go
+++ b/list.go
@@ -30,23 +30,17 @@ type List struct {
 	// Whether or not to show the secondary item texts.
 	showSecondaryText bool
 
-	// The item main text color.
-	mainTextColor tcell.Color
+	// The item main text style.
+    mainTextStyle tcell.Style
 
-	// The item secondary text color.
-	secondaryTextColor tcell.Color
+	// The item secondary text style.
+    secondaryTextStyle tcell.Style
 
-	// The item shortcut text color.
-	shortcutColor tcell.Color
+	// The item shortcut text style.
+    shortcutStyle tcell.Style
 
-	// The text color for selected items.
-	selectedTextColor tcell.Color
-
-	// The background color for selected items.
-	selectedBackgroundColor tcell.Color
-
-	// Whether or not to reverse color for selected items.
-	selectedReverseColor bool
+	// The text style for selected items.
+	selectedTextStyle tcell.Style
 
 	// If true, the selection is only shown when the list has focus.
 	selectedFocusOnly bool
@@ -84,15 +78,15 @@ type List struct {
 
 // NewList returns a new form.
 func NewList() *List {
+	base := tcell.StyleDefault.Background(Styles.PrimitiveBackgroundColor)
 	return &List{
 		Box:                     NewBox(),
 		showSecondaryText:       true,
 		wrapAround:              true,
-		mainTextColor:           Styles.PrimaryTextColor,
-		secondaryTextColor:      Styles.TertiaryTextColor,
-		shortcutColor:           Styles.SecondaryTextColor,
-		selectedTextColor:       Styles.PrimitiveBackgroundColor,
-		selectedBackgroundColor: Styles.PrimaryTextColor,
+		mainTextStyle:           base.Foreground(Styles.PrimaryTextColor),
+		secondaryTextStyle:      base.Foreground(Styles.TertiaryTextColor),
+		shortcutStyle:           base.Foreground(Styles.SecondaryTextColor),
+		selectedTextStyle:       base.Foreground(Styles.PrimitiveBackgroundColor).Background(Styles.PrimaryTextColor),
 	}
 }
 
@@ -199,39 +193,31 @@ func (l *List) RemoveItem(index int) *List {
 
 // SetMainTextColor sets the color of the items' main text.
 func (l *List) SetMainTextColor(color tcell.Color) *List {
-	l.mainTextColor = color
+	l.mainTextStyle.Foreground(color)
 	return l
 }
 
 // SetSecondaryTextColor sets the color of the items' secondary text.
 func (l *List) SetSecondaryTextColor(color tcell.Color) *List {
-	l.secondaryTextColor = color
+	l.secondaryTextStyle.Foreground(color)
 	return l
 }
 
 // SetShortcutColor sets the color of the items' shortcut.
 func (l *List) SetShortcutColor(color tcell.Color) *List {
-	l.shortcutColor = color
+	l.shortcutStyle.Foreground(color)
 	return l
 }
 
 // SetSelectedTextColor sets the text color of selected items.
 func (l *List) SetSelectedTextColor(color tcell.Color) *List {
-	l.selectedTextColor = color
+	l.selectedTextStyle.Foreground(color)
 	return l
 }
 
 // SetSelectedBackgroundColor sets the background color of selected items.
 func (l *List) SetSelectedBackgroundColor(color tcell.Color) *List {
-	l.selectedBackgroundColor = color
-	return l
-}
-
-// SetSelectedReverseColor sets a flag which determines if the colors
-// of the selected items are reversed. If set to true, the colors set by
-// SetSelectedTextColor and SetSelectedBackgroundColor are ignored.
-func (l *List) SetSelectedReverseColor(reverse bool) *List {
-	l.selectedReverseColor = reverse
+	l.selectedTextStyle.Background(color)
 	return l
 }
 
@@ -484,11 +470,11 @@ func (l *List) Draw(screen tcell.Screen) {
 
 		// Shortcuts.
 		if showShortcuts && item.Shortcut != 0 {
-			Print(screen, fmt.Sprintf("(%s)", string(item.Shortcut)), x-5, y, 4, AlignRight, l.shortcutColor)
+			printWithStyle(screen, fmt.Sprintf("(%s)", string(item.Shortcut)), x-5, y, 0, 4, AlignRight, l.shortcutStyle, false)
 		}
 
 		// Main text.
-		_, printedWidth, _, end := printWithStyle(screen, item.MainText, x, y, l.horizontalOffset, width, AlignLeft, tcell.StyleDefault.Foreground(l.mainTextColor), true)
+		_, printedWidth, _, end := printWithStyle(screen, item.MainText, x, y, l.horizontalOffset, width, AlignLeft, l.mainTextStyle, false)
 		if printedWidth > maxWidth {
 			maxWidth = printedWidth
 		}
@@ -506,17 +492,8 @@ func (l *List) Draw(screen tcell.Screen) {
 			}
 
 			for bx := 0; bx < textWidth; bx++ {
-				m, c, style, _ := screen.GetContent(x+bx, y)
-				fg, _, _ := style.Decompose()
-				if fg == l.mainTextColor {
-					fg = l.selectedTextColor
-				}
-                if l.selectedReverseColor {
-                    style = style.Reverse(true)
-                } else {
-                    style = style.Background(l.selectedBackgroundColor).Foreground(fg)
-                }
-				screen.SetContent(x+bx, y, m, c, style)
+				m, c, _, _ := screen.GetContent(x+bx, y)
+				screen.SetContent(x+bx, y, m, c, l.selectedTextStyle)
 			}
 		}
 
@@ -528,7 +505,7 @@ func (l *List) Draw(screen tcell.Screen) {
 
 		// Secondary text.
 		if l.showSecondaryText {
-			_, printedWidth, _, end := printWithStyle(screen, item.SecondaryText, x, y, l.horizontalOffset, width, AlignLeft, tcell.StyleDefault.Foreground(l.secondaryTextColor), true)
+			_, printedWidth, _, end := printWithStyle(screen, item.SecondaryText, x, y, l.horizontalOffset, width, AlignLeft, l.secondaryTextStyle, false)
 			if printedWidth > maxWidth {
 				maxWidth = printedWidth
 			}

--- a/list.go
+++ b/list.go
@@ -45,6 +45,9 @@ type List struct {
 	// The background color for selected items.
 	selectedBackgroundColor tcell.Color
 
+	// Whether or not to reverse color for selected items.
+	selectedReverseColor bool
+
 	// If true, the selection is only shown when the list has focus.
 	selectedFocusOnly bool
 
@@ -221,6 +224,14 @@ func (l *List) SetSelectedTextColor(color tcell.Color) *List {
 // SetSelectedBackgroundColor sets the background color of selected items.
 func (l *List) SetSelectedBackgroundColor(color tcell.Color) *List {
 	l.selectedBackgroundColor = color
+	return l
+}
+
+// SetSelectedReverseColor sets a flag which determines if the colors
+// of the selected items are reversed. If set to true, the colors set by
+// SetSelectedTextColor and SetSelectedBackgroundColor are ignored.
+func (l *List) SetSelectedReverseColor(reverse bool) *List {
+	l.selectedReverseColor = reverse
 	return l
 }
 
@@ -500,7 +511,11 @@ func (l *List) Draw(screen tcell.Screen) {
 				if fg == l.mainTextColor {
 					fg = l.selectedTextColor
 				}
-				style = style.Background(l.selectedBackgroundColor).Foreground(fg)
+                if l.selectedReverseColor {
+                    style = style.Reverse(true)
+                } else {
+                    style = style.Background(l.selectedBackgroundColor).Foreground(fg)
+                }
 				screen.SetContent(x+bx, y, m, c, style)
 			}
 		}

--- a/list.go
+++ b/list.go
@@ -197,15 +197,33 @@ func (l *List) SetMainTextColor(color tcell.Color) *List {
 	return l
 }
 
+// SetMainTextStyle sets the style of the items' main text.
+func (l *List) SetMainTextStyle(style tcell.Style) *List {
+	l.mainTextStyle = style
+	return l
+}
+
 // SetSecondaryTextColor sets the color of the items' secondary text.
 func (l *List) SetSecondaryTextColor(color tcell.Color) *List {
 	l.secondaryTextStyle.Foreground(color)
 	return l
 }
 
+// SetSecondaryTextStyle sets the style of the items' secondary text.
+func (l *List) SetSecondaryTextStyle(style tcell.Style) *List {
+	l.secondaryTextStyle = style
+	return l
+}
+
 // SetShortcutColor sets the color of the items' shortcut.
 func (l *List) SetShortcutColor(color tcell.Color) *List {
 	l.shortcutStyle.Foreground(color)
+	return l
+}
+
+// SetShortcutStyle sets the style of the items' shortcut.
+func (l *List) SetShortcutStyle(style tcell.Style) *List {
+	l.shortcutStyle = style
 	return l
 }
 
@@ -218,6 +236,12 @@ func (l *List) SetSelectedTextColor(color tcell.Color) *List {
 // SetSelectedBackgroundColor sets the background color of selected items.
 func (l *List) SetSelectedBackgroundColor(color tcell.Color) *List {
 	l.selectedTextStyle.Background(color)
+	return l
+}
+
+// SetSelectedTextStyle sets the style of selected items.
+func (l *List) SetSelectedTextStyle(style tcell.Style) *List {
+	l.selectedTextStyle = style
 	return l
 }
 


### PR DESCRIPTION
I'm working on xterm with disabled color support. This patch allows me to see the currently selected item in a list. This is probably not a good solution, there are surley be other widgets with similar problems. But i just wanted to see if the reverse code worked.

What do you think about adding a api, where i can just set styles directly for elements? Like _SetSelectedStyle_, _SetBorderStyle_, etc? 