### PR TITLE
Add support for styling the borders used with modals.

### DIFF
--- a/modal.go
+++ b/modal.go
@@ -77,6 +77,18 @@ func (m *Modal) SetButtonTextColor(color tcell.Color) *Modal {
 	return m
 }
 
+// SetBorderColor sets the color of the border.
+func (m *Modal) SetBorderColor(color tcell.Color) *Modal {
+	m.frame.SetBorderColor(color)
+	return m
+}
+
+// SetBorder enables or disables the display of the border
+func (m *Modal) SetBorder(show bool) *Modal {
+	m.frame.SetBorder(show)
+	return m
+}
+
 // SetDoneFunc sets a handler which is called when one of the buttons was
 // pressed. It receives the index of the button as well as its label text. The
 // handler is also called when the user presses the Escape key. The index will


### PR DESCRIPTION
It turns out that I need to have more control over the styling of these borders.  This small addition fixes that.  (Note that due to inheritance from Box we had this method already, but it basically didn't do what you expected -- we need to control the frame's borders, not the box's.