### PR TITLE
Make TextView.Clear safe

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -419,6 +419,8 @@ func (t *TextView) GetScrollOffset() (row, column int) {
 
 // Clear removes all text from the buffer.
 func (t *TextView) Clear() *TextView {
+	t.Lock()
+	defer t.Unlock()
 	t.buffer = nil
 	t.recentBytes = nil
 	t.index = nil


### PR DESCRIPTION
Fix https://github.com/rivo/tview/issues/636

I think the problem is TextView.Clear is not locking.
When we clear the TextView, the buffer will be nil.
So call Clear while drawing buffer, it will panic with that stack trace.

```
github.com/rivo/tview.(*TextView).Draw(0xc0000bc100, {0xa43700, 0xc000568000})
        /home/sam/go/pkg/mod/github.com/rivo/tview@v0.0.0-20210624165335-29d673af0ce2/textview.go:1017 +0xdf4
```