### PR TITLE
Fix deadlock in SetText

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -311,11 +311,11 @@ func (t *TextView) SetTextColor(color tcell.Color) *TextView {
 // SetText sets the text of this text view to the provided string. Previously
 // contained text will be removed.
 func (t *TextView) SetText(text string) *TextView {
-	t.Lock()
-	defer t.Unlock()
+	batch := t.BatchWriter()
+	defer batch.Close()
 
-	t.clear()
-	fmt.Fprint(t, text)
+	batch.Clear()
+	fmt.Fprint(batch, text)
 	return t
 }
 


### PR DESCRIPTION
I realized right as I saw the email that the batch stuff had been merged that my change to the locking in SetText would obviously cause a deadlock (we aquire the lock, then the Write method is called which also tries to aquire the lock).

If you'd permit me, I'd like to write tests for some of the functions in this library, it could have prevented this being merged in the first place if I'd written some tests about it. While you consider it though I've pushed up this fix quickly that at least lets SetText be usable again.