### PR TITLE
adding `abdfnx/resto` to the list of projects that use tview

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ For a presentation highlighting this package, compile and run the program found 
 - [tvxwidgets: tview extra widgets](https://github.com/navidys/tvxwidgets)
 - [Domino card game on terminal](https://github.com/gusti-andika/card-domino.git)
 - [goaround: Query stackoverflow API and get results on terminal](https://github.com/glendsoza/goaround)
+- [resto: 🔗 a CLI app can send pretty HTTP & API requests with TUI](https://github.com/abdfnx/resto)
 
 ## Documentation
 


### PR DESCRIPTION
adding [`abdfnx/resto`](https://github.com/abdfnx/resto) to the list of projects that use tview in **README.md**