### PR TITLE
Fix application deadlock on keyevent in blank selectable Table. Fixes #705

### DIFF
--- a/table.go
+++ b/table.go
@@ -1335,9 +1335,15 @@ func (t *Table) InputHandler() func(event *tcell.EventKey, setFocus func(p Primi
 				startColumn := t.selectedColumn
 				for {
 					cell := t.content.GetCell(t.selectedRow, t.selectedColumn)
+
 					if cell != nil && !cell.NotSelectable {
 						return
 					}
+
+					if lastColumn < 0 || (rowCount-1) < 0 {
+						return
+					}
+
 					t.selectedColumn--
 					if t.selectedColumn < 0 {
 						t.selectedColumn = lastColumn
@@ -1346,6 +1352,7 @@ func (t *Table) InputHandler() func(event *tcell.EventKey, setFocus func(p Primi
 							t.selectedRow = rowCount - 1
 						}
 					}
+
 					if t.selectedColumn == startColumn && t.selectedRow == startRow {
 						t.selectedColumn = 0
 						t.selectedRow = 0


### PR DESCRIPTION
Please see #705 for the initial details.

The issue occurs at this [line](https://github.com/rivo/tview/blob/96063d6082f31f7f5b2d3a8fdc296251cc36514e/table.go#L1330):
```go
lastColumn := t.content.GetColumnCount() - 1
rowCount := t.content.GetRowCount()

previous := func() {
		startRow := t.selectedRow
		startColumn := t.selectedColumn
		for {
			cell := t.content.GetCell(t.selectedRow, t.selectedColumn)
			if cell != nil && !cell.NotSelectable {
				return
			}
			t.selectedColumn--
			if t.selectedColumn < 0 {
				t.selectedColumn = lastColumn
				t.selectedRow--
				if t.selectedRow < 0 {
					t.selectedRow = rowCount - 1
				}
			}
			if t.selectedColumn == startColumn && t.selectedRow == startRow {
				t.selectedColumn = 0
				t.selectedRow = 0
				return
			}
		}
	}
```

As mentioned before, the Table is **selectable**, so the condition `!cell.NotSelectable` will return **false**, so the function does not return.

In a blank table with no rows and no columns, `t.content.GetColumnCount()` and `t.content.GetRowCount()` will return 0, and therefore `lastColumn` and `rowCount` will be evaluated to -1 and 0 respectively, which in turn will set `selectedColumn` and `selectedRow` to -1. 

Consequently, `t.selectedColumn` and `t.selectedRow` will not match `startColumn` and `startRow` respectively, and therefore the function will not return. This in turn causes an infinite loop, with very high CPU usage.

A possible fix is to check whether `lastColumn` and `rowCount-1` are negative values, before proceeding further.