### PR TITLE
Fix the DropDown list when too close to the right screen edge

### DIFF
--- a/dropdown.go
+++ b/dropdown.go
@@ -395,12 +395,20 @@ func (d *DropDown) Draw(screen tcell.Screen) {
 
 	// Draw options list.
 	if d.HasFocus() && d.open {
-		// We prefer to drop down but if there is no space, maybe drop up?
 		lx := x
 		ly := y + 1
 		lwidth := maxWidth
 		lheight := len(d.options)
-		_, sheight := screen.Size()
+		swidth, sheight := screen.Size()
+		// We prefer to align the left sides of the list and the main widget, but
+		// if there is no space to the right, then shift the list to the left.
+		if lx+lwidth >= swidth {
+			lx = swidth - lwidth
+			if lx < 0 {
+				lx = 0
+			}
+		}
+		// We prefer to drop down but if there is no space, maybe drop up?
 		if ly+lheight >= sheight && ly-2 > lheight-ly {
 			ly = y - lheight
 			if ly < 0 {


### PR DESCRIPTION
There was a bug: DropDown always aligns the left edge of selection list and the main widget, but when the widget is too close to the right screen edge, the list ends up being drawn only partially. See screenshot: here, "Menu" is the dropdown:

![image](https://user-images.githubusercontent.com/1329932/164967688-f436e783-5010-4839-a4ec-d6baba2a7c18.png)

This is how it looks after the fix:

![image](https://user-images.githubusercontent.com/1329932/164967605-c806a1b5-cd6d-4a36-a81e-c1fa2d084e43.png)

When there is enough room on the right side, dropdown list is drawn exactly as it used to.

Fixes #726.