### PR TITLE
Add ability to style list items

### DIFF
--- a/demos/list/withstyle/README.md
+++ b/demos/list/withstyle/README.md
@@ -1,0 +1,1 @@
+![Screenshot](screenshot.png)

--- a/demos/list/withstyle/main.go
+++ b/demos/list/withstyle/main.go
@@ -1,0 +1,39 @@
+// Demo code for the List primitive with style.
+package main
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+func main() {
+	var mStyle, sStyle tcell.Style
+
+	app := tview.NewApplication()
+	list := tview.NewList()
+
+	mStyle = tcell.StyleDefault.Foreground(tcell.ColorBlue)
+	sStyle = tcell.StyleDefault.Foreground(tcell.ColorBeige)
+	list.AddItemWithStyle("List item 1", "Some explanatory text", 'a', nil, mStyle, sStyle)
+
+	mStyle = tcell.StyleDefault.Foreground(tcell.ColorPink)
+	sStyle = tcell.StyleDefault.Foreground(tcell.ColorDarkGreen)
+	list.AddItemWithStyle("List item 2", "Some explanatory text", 'b', nil, mStyle, sStyle)
+
+	mStyle = tcell.StyleDefault.Foreground(tcell.ColorViolet)
+	sStyle = tcell.StyleDefault.Foreground(tcell.ColorSlateGrey)
+	list.AddItemWithStyle("List item 3", "Some explanatory text", 'c', nil, mStyle, sStyle)
+
+	mStyle = tcell.StyleDefault.Foreground(tcell.ColorGold)
+	sStyle = tcell.StyleDefault.Foreground(tcell.ColorWhite)
+	list.AddItemWithStyle("List item 4", "Some explanatory text", 'd', nil, mStyle, sStyle)
+
+	mStyle = tcell.StyleDefault.Foreground(tcell.ColorRed)
+	sStyle = tcell.StyleDefault.Foreground(tcell.ColorBlack)
+	list.AddItemWithStyle("Quit", "Press to exit", 'q', func() {
+		app.Stop()
+	}, mStyle, sStyle)
+	if err := app.SetRoot(list, true).EnableMouse(true).Run(); err != nil {
+		panic(err)
+	}
+}

--- a/list.go
+++ b/list.go
@@ -13,8 +13,8 @@ type listItem struct {
 	SecondaryText      string      // A secondary text to be shown underneath the main text.
 	Shortcut           rune        // The key to select the list item directly, 0 if there is no shortcut.
 	Selected           func()      // The optional function which is called when the item is selected.
-	MainTextStyle      tcell.Style // The style for the main text
-	SecondarytextStyle tcell.Style // The style for the secondary text
+	MainTextStyle      tcell.Style // The style for the main text.
+	SecondarytextStyle tcell.Style // The style for the secondary text.
 }
 
 // List displays rows of items, each of which can be selected.
@@ -363,7 +363,7 @@ func (l *List) InsertItem(index int, mainText, secondaryText string, shortcut ru
 	return l
 }
 
-// insert an item in the list
+// insert an item in the list.
 func (l *List) insertItem(index int, mainText, secondaryText string, shortcut rune, selected func(), mainTextStyle, secondaryTextStyle tcell.Style) *List {
 	item := &listItem{
 		MainText:           mainText,


### PR DESCRIPTION
This PR adds the ability to style items of a list by providing the foreground color of the text (`mainTextStyle`) as well as the description (`secondaryTextStyle`).

It adds two functions to `list.go` that accept a style (`tcell.Style`):
* `AddItemWithStyle`
* `InsertItemWithStyle`

I have also added a demo showing how it works
```go
	mStyle = tcell.StyleDefault.Foreground(tcell.ColorBlue)
	sStyle = tcell.StyleDefault.Foreground(tcell.ColorBeige)
	list.AddItemWithStyle("List item 1", "Some explanatory text", 'a', nil, mStyle, sStyle)
```

I haven't however yet added the screenshot since I didn't want to clutter git in case we need multiple iterations for this PR to get accepted.

In case this doesn't match your expectations / level of quality, I'm happy to improve it in any way you see fit to reach a level of quality that satisfies you, just drop me a line.