### PR TITLE
Update README.md - added loggo app on projects using tview

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For a presentation highlighting this package, compile and run the program found 
 - [pacseek: A TUI for searching and installing Arch Linux packages](https://github.com/moson-mo/pacseek)
 - [7GUIs demo](https://github.com/letientai299/7guis/tree/master/tui)
 - [tuihub: A utility hub/dashboard for personal use](https://github.com/ashis0013/tuihub)
-- [l'oggo: A powerful terminal app for structured log streaming (GCP stack driver, k9s, local streaming)](https://github.com/aurc/loggo)
+- [l'oggo: A terminal app for structured log streaming (GCP stack driver, k8s, local streaming)](https://github.com/aurc/loggo)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ For a presentation highlighting this package, compile and run the program found 
 - [pacseek: A TUI for searching and installing Arch Linux packages](https://github.com/moson-mo/pacseek)
 - [7GUIs demo](https://github.com/letientai299/7guis/tree/master/tui)
 - [tuihub: A utility hub/dashboard for personal use](https://github.com/ashis0013/tuihub)
+- [l'oggo: A powerful terminal app for structured log streaming (GCP stack driver, k9s, local streaming)](https://github.com/aurc/loggo)
 
 ## Documentation
 


### PR DESCRIPTION
Listed loggo in the projects that are using tview in the README.md: A terminal app for structured log streaming (GCP stack driver, k8s, local streaming)