### PR TITLE
Initialise Screen if SetScreen called before Run

### DIFF
--- a/application.go
+++ b/application.go
@@ -181,6 +181,7 @@ func (a *Application) SetScreen(screen tcell.Screen) *Application {
 		// Run() has not been called yet.
 		a.screen = screen
 		a.Unlock()
+		screen.Init()
 		return a
 	}
 
@@ -284,9 +285,8 @@ func (a *Application) Run() error {
 			a.screen = screen
 			enableMouse := a.enableMouse
 			a.Unlock()
-
 			// Initialize and draw this screen.
-			if err := a.screen.Init(); err != nil {
+			if err := screen.Init(); err != nil {
 				panic(err)
 			}
 			if enableMouse {

--- a/application.go
+++ b/application.go
@@ -285,6 +285,7 @@ func (a *Application) Run() error {
 			a.screen = screen
 			enableMouse := a.enableMouse
 			a.Unlock()
+
 			// Initialize and draw this screen.
 			if err := screen.Init(); err != nil {
 				panic(err)

--- a/application.go
+++ b/application.go
@@ -286,7 +286,7 @@ func (a *Application) Run() error {
 			a.Unlock()
 
 			// Initialize and draw this screen.
-			if err := screen.Init(); err != nil {
+			if err := a.screen.Init(); err != nil {
 				panic(err)
 			}
 			if enableMouse {


### PR DESCRIPTION
 #756

The bug came from the `a.screen == nil` check in `Application.SetScreen` skipping the a.screenReplacement channel and just setting `a.screen` directly. This skipped the code following `screen = <-a.screenReplacement` meaning the new screen never got initialised.

I'm not sure if the correct fix is to init the screen if `a.screen == nil` as I've done in this PR, or whether it would be better to pass the new screen into the screen channel whether or not there is already a screen present.