### PR TITLE
fix deadlocking nonscrollable textview #797

### DIFF
--- a/textview.go
+++ b/textview.go
@@ -1463,6 +1463,9 @@ func (t *TextView) MouseHandler() func(action MouseAction, event *tcell.EventMou
 		if !t.InRect(x, y) {
 			return false, nil
 		}
+		if !t.scrollable {
+			return false,nil
+		}
 
 		switch action {
 		case MouseLeftDown:


### PR DESCRIPTION
Resolves the issue with the textviews when set non-scrollable in a form causing a deadlock with the focus handlers set by the form.

Since the `t.scrollable=false` seems to mean the textview is read-only plus no scrolling the mouse handler should return earlier so no setFocus handlers run.

#797 should be resolved by this.