### PR TITLE
Grid items can be cleared after the given index

### DIFF
--- a/grid.go
+++ b/grid.go
@@ -227,6 +227,15 @@ func (g *Grid) Clear() *Grid {
 	return g
 }
 
+// ClearAfter removes all items starting with the given index.
+func (g *Grid) ClearAfter(index int) *Grid {
+	if len(g.items) <= index {
+		return g
+	}
+	g.items = g.items[:index]
+	return g
+}
+
 // SetOffset sets the number of rows and columns which are skipped before
 // drawing the first grid cell in the top-left corner. As the grid will never
 // completely move off the screen, these values may be adjusted the next time


### PR DESCRIPTION
I'd like to use grid as a table having the first n items headers. So every time I want to load new content to it, I can remove the rest after the headers and fill it up with new widgets.