### PR TITLE
 add GetScreenSize to application

### DIFF
--- a/application.go
+++ b/application.go
@@ -201,6 +201,11 @@ func (a *Application) SetScreen(screen tcell.Screen) *Application {
 	return a
 }
 
+// GetScreenSize returns the size of the screen.
+func (a *Application) GetScreenSize() (int, int) {
+	return a.screen.Size()
+}
+
 // EnableMouse enables mouse events or disables them (if "false" is provided).
 func (a *Application) EnableMouse(enable bool) *Application {
 	a.Lock()


### PR DESCRIPTION
"GetScreenSize" is a useful method in the "Application" struct that can be used to obtain the current size of the application's screen.
This function is particularly useful for managing the layout of an application, as it allows you to adjust the display based on the screen size. 