### PR TITLE
Closes #844  Fix TextArea's SetText by resetting nextUndo counter

### DIFF
--- a/textarea.go
+++ b/textarea.go
@@ -385,6 +385,7 @@ func (t *TextArea) SetText(text string, cursorAtTheEnd bool) *TextArea {
 	t.cursor.row, t.cursor.actualColumn, t.cursor.column = 0, 0, 0
 	t.cursor.pos = [3]int{1, 0, -1}
 	t.undoStack = t.undoStack[:0]
+	t.nextUndo = 0
 
 	if len(text) > 0 {
 		t.spans = append(t.spans, textAreaSpan{


### PR DESCRIPTION
TextArea's method `SetText()` has wrong undo logic. Currently only `undoStack` has reset, which means, if `SetText()` called second time, `nextUndo` counter stays the same. If press `Ctrl-Z` right after second `SetText()` it trying to reach `nextUndo` position into empty `undoStack` and get panic