### PR TITLE
add setdontclear for cases where padding and borders on primitives

### DIFF
--- a/box.go
+++ b/box.go
@@ -82,6 +82,13 @@ func NewBox() *Box {
 	return b
 }
 
+// SetDontClear sets whether the draw function 
+// clears the bg with defined color
+func (b *Box) SetDontClear(dontClear bool) *Box {
+	b.dontClear = dontClear
+	return b
+}
+
 // SetBorderPadding sets the size of the borders around the box content.
 func (b *Box) SetBorderPadding(top, bottom, left, right int) *Box {
 	b.paddingTop, b.paddingBottom, b.paddingLeft, b.paddingRight = top, bottom, left, right


### PR DESCRIPTION
some primitives set `Box.dontClear = true` which screws up padding/borders that arent including a bg color in Flex and i believe Frame/Table.

This is in reference to #833 

For a flex there should be no reason you need to sest a item as a `Box` instead of nil just to get the BG color. It also doesn't solve padding issues. 

```go

	layoutCol2 := tview.NewFlex().
		SetDirection(tview.FlexRow).
		AddItem(identificationTextview, 3, 0, false).
		AddItem(valueInput, 1, 0, false).
		AddItem(detailsTextview, 6, 0, false)
	layoutCol2.SetBorder(true)
	layoutCol2.SetBorderPadding(0, 0, 1, 1)

    // re-enable dontClear for this padding on a flex
    layoutCol2.SetDontClear(false)
```