### PR TITLE
Fix maximum field width for InputField

### DIFF
--- a/inputfield.go
+++ b/inputfield.go
@@ -457,8 +457,9 @@ func (i *InputField) Draw(screen tcell.Screen) {
 		labelWidth = TaggedStringWidth(i.textArea.GetLabel())
 	}
 	fieldWidth := i.fieldWidth
-	if fieldWidth == 0 {
-		fieldWidth = width - labelWidth
+	maxWidth := width - labelWidth
+	if fieldWidth == 0 || fieldWidth > maxWidth {
+		fieldWidth = maxWidth
 	}
 	i.textArea.SetRect(x, y, labelWidth+fieldWidth, 1)
 	i.textArea.setMinCursorPadding(fieldWidth-1, 1)


### PR DESCRIPTION
Limit the width to the maximum available width before drawing an `InputField`.

Currently it might draw over borders and other elements:

![image](https://github.com/rivo/tview/assets/13588013/a4f6360d-4b47-4c50-9e65-b5a00a1ed6a2)
