### PR TITLE
fix remove dropdown option index out of range

### DIFF
--- a/dropdown.go
+++ b/dropdown.go
@@ -518,13 +518,10 @@ func (d *DropDown) openList(setFocus func(Primitive)) {
 		}
 		if len(d.options) != 0 {
 			if d.currentOption >= len(d.options) {
-				if d.options[d.currentOption-1].Selected != nil {
-					d.options[d.currentOption-1].Selected()
-				}
-			} else {
-				if d.options[d.currentOption].Selected != nil {
-					d.options[d.currentOption].Selected()
-				}
+				d.currentOption--
+			}
+			if d.options[d.currentOption].Selected != nil {
+				d.options[d.currentOption].Selected()
 			}
 		}
 	}).SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {

--- a/dropdown.go
+++ b/dropdown.go
@@ -516,8 +516,16 @@ func (d *DropDown) openList(setFocus func(Primitive)) {
 		if d.selected != nil {
 			d.selected(d.options[d.currentOption].Text, d.currentOption)
 		}
-		if d.options[d.currentOption].Selected != nil {
-			d.options[d.currentOption].Selected()
+		if len(d.options) != 0 {
+			if d.currentOption >= len(d.options) {
+				if d.options[d.currentOption-1].Selected != nil {
+					d.options[d.currentOption-1].Selected()
+				}
+			} else {
+				if d.options[d.currentOption].Selected != nil {
+					d.options[d.currentOption].Selected()
+				}
+			}
 		}
 	}).SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyRune {


### PR DESCRIPTION
@rivo 

Hi, when setSelectFunc of dropdown to remove current option, if the last option is selected, index out of range will panic. I tried to fix this bug.

The code below will reproduce this bug if select the last option `Fifth`.

```go
package main

import "github.com/rivo/tview"

func main() {
	app := tview.NewApplication()
	dropdown := tview.NewDropDown()
	dropdown.SetLabel("Select an option (hit Enter): ")
	selectFunc := func(text string, index int) {
		dropdown.RemoveOption(index)
	}
	dropdown.SetOptions([]string{"First", "Second", "Third", "Fourth", "Fifth"}, selectFunc)
	if err := app.SetRoot(dropdown, true).EnableMouse(true).Run(); err != nil {
		panic(err)
	}
}

```