### PR TITLE
fixing #959 textview mouse out of bounds fix

### DIFF
--- a/box.go
+++ b/box.go
@@ -260,8 +260,8 @@ func (b *Box) InRect(x, y int) bool {
 	return x >= rectX && x < rectX+width && y >= rectY && y < rectY+height
 }
 
-// InRect returns true if the given coordinate is within the bounds of the box's
-// rectangle.
+// InInnerRect returns true if the given coordinate is within the bounds of the box's
+// inner rectangle (within the border, and padding).
 func (b *Box) InInnerRect(x, y int) bool {
 	rectX, rectY, width, height := b.GetInnerRect()
 	return x >= rectX && x < rectX+width && y >= rectY && y < rectY+height

--- a/box.go
+++ b/box.go
@@ -260,6 +260,13 @@ func (b *Box) InRect(x, y int) bool {
 	return x >= rectX && x < rectX+width && y >= rectY && y < rectY+height
 }
 
+// InRect returns true if the given coordinate is within the bounds of the box's
+// rectangle.
+func (b *Box) InInnerRect(x, y int) bool {
+	rectX, rectY, width, height := b.GetInnerRect()
+	return x >= rectX && x < rectX+width && y >= rectY && y < rectY+height
+}
+
 // GetMouseCapture returns the function installed with SetMouseCapture() or nil
 // if no such function has been installed.
 func (b *Box) GetMouseCapture() func(action MouseAction, event *tcell.EventMouse) (MouseAction, *tcell.EventMouse) {

--- a/textview.go
+++ b/textview.go
@@ -1377,7 +1377,7 @@ func (t *TextView) MouseHandler() func(action MouseAction, event *tcell.EventMou
 			setFocus(t)
 			consumed = true
 		case MouseLeftClick:
-			if t.regionTags {
+			if t.regionTags && t.InInnerRect(x, y) {
 				// Find a region to highlight.
 				x -= rectX
 				y -= rectY


### PR DESCRIPTION
#959 bails if user clicks on border of textview when regions enabled

- added `*Box.InInnerRect(x,y int)` helper to check if some coord is inside the ***inner*** rect (inside border/padding)
- added check using the helper within `*TextView` mouse handler to ensure that if regions are enabled, and will be checked, that the event occurred WITHIN the inner rect since borders/padding are excluded


```go
package main

import (
        "fmt"
        "log"

        "github.com/rivo/tview"
)

func main() {
        tabs := tview.NewTextView().SetRegions(true)
        tabs.SetBorder(true)
				tabs.SetDynamicColors(true)


        myApp := tview.NewApplication()
        myApp.EnableMouse(true)
				// tabs.SetToggleHighlights(true)

        myFlex := tview.NewFlex().SetDirection(tview.FlexRow).
                AddItem(
                        tview.NewFlex().
                                AddItem(tabs, 30, 0, false),
                        5, 0, false,
                )

        fmt.Fprintf(tabs, `
["%s"][white]%s[""]
[red] vv %s vv
["%s"][green]%s[""]
`, "0", "Anything", "Long Text","2","Anythong")

        if err := myApp.SetRoot(myFlex, true).Run(); err != nil {
                log.Fatal(err)
        }
}

```

![Peek 2024-03-28 20-25](https://github.com/rivo/tview/assets/1828125/be2c9ca8-606e-49bd-8b7e-f4b7c11791a9)
