### PR TITLE
Fix consume status of mouse events in custom capture

### DIFF
--- a/box.go
+++ b/box.go
@@ -221,6 +221,9 @@ func (b *Box) WrapMouseHandler(mouseHandler func(MouseAction, *tcell.EventMouse,
 	return func(action MouseAction, event *tcell.EventMouse, setFocus func(p Primitive)) (consumed bool, capture Primitive) {
 		if b.mouseCapture != nil {
 			action, event = b.mouseCapture(action, event)
+			if event == nil {
+				consumed = true
+			}
 		}
 		if event != nil && mouseHandler != nil {
 			consumed, capture = mouseHandler(action, event, setFocus)


### PR DESCRIPTION
At present, it is not possible to consume events in the mouse event capture function, even if you return nil. This causes (among other things) `Application.draw()` to not fire properly, and essentially, means that any gui state changes you make inside the capture function, isn't rendered.

This PR hopefully fixes that. I couldn't find any tests to modify/change, do you need any other info?

The following code (from the Application event loop) shows where the draw call would be skipped when the wrong consume status is returned

```
case *tcell.EventMouse:
	consumed, isMouseDownAction := a.fireMouseActions(event)
	if consumed {
		a.draw()
	}
	a.lastMouseButtons = event.Buttons()
	if isMouseDownAction {
		a.mouseDownX, a.mouseDownY = event.Position()
	}
```