### PR TITLE
Proof of concept: add support for opt-in inside-out keyboard event propagation

### DIFF
--- a/application.go
+++ b/application.go
@@ -401,7 +401,7 @@ EventLoop:
 				// Pass other key events to the root primitive.
 				if root != nil && root.HasFocus() {
 					if handler := root.InputHandler(); handler != nil {
-						handler(event, func(p Primitive) {
+						_ = handler(event, func(p Primitive) {
 							a.SetFocus(p)
 						})
 						draw = true

--- a/button.go
+++ b/button.go
@@ -160,8 +160,8 @@ func (b *Button) Draw(screen tcell.Screen) {
 }
 
 // InputHandler returns the handler for this primitive.
-func (b *Button) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return b.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (b *Button) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return b.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		if b.disabled {
 			return
 		}
@@ -177,6 +177,8 @@ func (b *Button) InputHandler() func(event *tcell.EventKey, setFocus func(p Prim
 				b.exit(key)
 			}
 		}
+
+		return
 	})
 }
 

--- a/checkbox.go
+++ b/checkbox.go
@@ -279,8 +279,8 @@ func (c *Checkbox) Draw(screen tcell.Screen) {
 }
 
 // InputHandler returns the handler for this primitive.
-func (c *Checkbox) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return c.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (c *Checkbox) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return c.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		if c.disabled {
 			return
 		}
@@ -303,6 +303,8 @@ func (c *Checkbox) InputHandler() func(event *tcell.EventKey, setFocus func(p Pr
 				c.finished(key)
 			}
 		}
+
+		return
 	})
 }
 

--- a/demos/primitive/main.go
+++ b/demos/primitive/main.go
@@ -42,8 +42,8 @@ func (r *RadioButtons) Draw(screen tcell.Screen) {
 }
 
 // InputHandler returns the handler for this primitive.
-func (r *RadioButtons) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
-	return r.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) {
+func (r *RadioButtons) InputHandler() func(event *tcell.EventKey, setFocus func(p tview.Primitive)) (consumed bool) {
+	return r.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p tview.Primitive)) (consumed bool) {
 		switch event.Key() {
 		case tcell.KeyUp:
 			r.currentOption--
@@ -56,6 +56,8 @@ func (r *RadioButtons) InputHandler() func(event *tcell.EventKey, setFocus func(
 				r.currentOption = len(r.options) - 1
 			}
 		}
+
+		return
 	})
 }
 

--- a/dropdown.go
+++ b/dropdown.go
@@ -448,8 +448,8 @@ func (d *DropDown) Draw(screen tcell.Screen) {
 }
 
 // InputHandler returns the handler for this primitive.
-func (d *DropDown) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return d.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (d *DropDown) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return d.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		if d.disabled {
 			return
 		}
@@ -482,6 +482,8 @@ func (d *DropDown) InputHandler() func(event *tcell.EventKey, setFocus func(p Pr
 				d.finished(key)
 			}
 		}
+
+		return
 	})
 }
 

--- a/flex.go
+++ b/flex.go
@@ -247,16 +247,17 @@ func (f *Flex) MouseHandler() func(action MouseAction, event *tcell.EventMouse, 
 }
 
 // InputHandler returns the handler for this primitive.
-func (f *Flex) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return f.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (f *Flex) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return f.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		for _, item := range f.items {
 			if item.Item != nil && item.Item.HasFocus() {
 				if handler := item.Item.InputHandler(); handler != nil {
-					handler(event, setFocus)
+					consumed = handler(event, setFocus)
 					return
 				}
 			}
 		}
+		return
 	})
 }
 

--- a/form.go
+++ b/form.go
@@ -846,12 +846,12 @@ func (f *Form) MouseHandler() func(action MouseAction, event *tcell.EventMouse, 
 }
 
 // InputHandler returns the handler for this primitive.
-func (f *Form) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return f.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (f *Form) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return f.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		for _, item := range f.items {
 			if item != nil && item.HasFocus() {
 				if handler := item.InputHandler(); handler != nil {
-					handler(event, setFocus)
+					consumed = handler(event, setFocus)
 					return
 				}
 			}
@@ -860,11 +860,13 @@ func (f *Form) InputHandler() func(event *tcell.EventKey, setFocus func(p Primit
 		for _, button := range f.buttons {
 			if button.HasFocus() {
 				if handler := button.InputHandler(); handler != nil {
-					handler(event, setFocus)
+					consumed = handler(event, setFocus)
 					return
 				}
 			}
 		}
+
+		return
 	})
 }
 

--- a/frame.go
+++ b/frame.go
@@ -209,15 +209,16 @@ func (f *Frame) MouseHandler() func(action MouseAction, event *tcell.EventMouse,
 }
 
 // InputHandler returns the handler for this primitive.
-func (f *Frame) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return f.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (f *Frame) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return f.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		if f.primitive == nil {
 			return
 		}
 		if handler := f.primitive.InputHandler(); handler != nil {
-			handler(event, setFocus)
+			consumed = handler(event, setFocus)
 			return
 		}
+		return
 	})
 }
 

--- a/grid.go
+++ b/grid.go
@@ -653,14 +653,14 @@ func (g *Grid) MouseHandler() func(action MouseAction, event *tcell.EventMouse, 
 }
 
 // InputHandler returns the handler for this primitive.
-func (g *Grid) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return g.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (g *Grid) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return g.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		if !g.hasFocus {
 			// Pass event on to child primitive.
 			for _, item := range g.items {
 				if item != nil && item.Item.HasFocus() {
 					if handler := item.Item.InputHandler(); handler != nil {
-						handler(event, setFocus)
+						consumed = handler(event, setFocus)
 						return
 					}
 				}
@@ -698,6 +698,8 @@ func (g *Grid) InputHandler() func(event *tcell.EventKey, setFocus func(p Primit
 		case tcell.KeyRight:
 			g.columnOffset++
 		}
+
+		return
 	})
 }
 

--- a/inputfield.go
+++ b/inputfield.go
@@ -508,8 +508,8 @@ func (i *InputField) Draw(screen tcell.Screen) {
 }
 
 // InputHandler returns the handler for this primitive.
-func (i *InputField) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return i.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (i *InputField) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return i.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		if i.textArea.GetDisabled() {
 			return
 		}
@@ -610,8 +610,10 @@ func (i *InputField) InputHandler() func(event *tcell.EventKey, setFocus func(p 
 			fallthrough
 		default:
 			// Forward other key events to the text area.
-			i.textArea.InputHandler()(event, setFocus)
+			consumed = i.textArea.InputHandler()(event, setFocus)
 		}
+
+		return
 	})
 }
 

--- a/list.go
+++ b/list.go
@@ -568,8 +568,8 @@ func (l *List) adjustOffset() {
 }
 
 // InputHandler returns the handler for this primitive.
-func (l *List) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return l.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (l *List) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return l.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		if event.Key() == tcell.KeyEscape {
 			if l.done != nil {
 				l.done()
@@ -663,6 +663,8 @@ func (l *List) InputHandler() func(event *tcell.EventKey, setFocus func(p Primit
 			}
 			l.adjustOffset()
 		}
+
+		return
 	})
 }
 

--- a/modal.go
+++ b/modal.go
@@ -202,13 +202,14 @@ func (m *Modal) MouseHandler() func(action MouseAction, event *tcell.EventMouse,
 }
 
 // InputHandler returns the handler for this primitive.
-func (m *Modal) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return m.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (m *Modal) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return m.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		if m.frame.HasFocus() {
 			if handler := m.frame.InputHandler(); handler != nil {
-				handler(event, setFocus)
+				consumed = handler(event, setFocus)
 				return
 			}
 		}
+		return
 	})
 }

--- a/pages.go
+++ b/pages.go
@@ -303,16 +303,17 @@ func (p *Pages) MouseHandler() func(action MouseAction, event *tcell.EventMouse,
 }
 
 // InputHandler returns the handler for this primitive.
-func (p *Pages) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return p.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (p *Pages) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return p.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		for _, page := range p.pages {
 			if page.Item.HasFocus() {
 				if handler := page.Item.InputHandler(); handler != nil {
-					handler(event, setFocus)
+					consumed = handler(event, setFocus)
 					return
 				}
 			}
 		}
+		return
 	})
 }
 

--- a/primitive.go
+++ b/primitive.go
@@ -32,7 +32,7 @@ type Primitive interface {
 	// The Box class provides functionality to intercept keyboard input. If you
 	// subclass from Box, it is recommended that you wrap your handler using
 	// Box.WrapInputHandler() so you inherit that functionality.
-	InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive))
+	InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool)
 
 	// Focus is called by the application when the primitive receives focus.
 	// Implementers may call delegate() to pass the focus on to another primitive.

--- a/table.go
+++ b/table.go
@@ -1366,8 +1366,8 @@ func (t *Table) Draw(screen tcell.Screen) {
 }
 
 // InputHandler returns the handler for this primitive.
-func (t *Table) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return t.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (t *Table) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return t.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		key := event.Key()
 
 		if (!t.rowsSelectable && !t.columnsSelectable && key == tcell.KeyEnter) ||
@@ -1682,6 +1682,8 @@ func (t *Table) InputHandler() func(event *tcell.EventKey, setFocus func(p Primi
 				t.columnsSelectable && previouslySelectedColumn != t.selectedColumn) {
 			t.selectionChanged(t.selectedRow, t.selectedColumn)
 		}
+
+		return
 	})
 }
 

--- a/textarea.go
+++ b/textarea.go
@@ -1945,8 +1945,8 @@ func (t *TextArea) getSelectedText() string {
 }
 
 // InputHandler returns the handler for this primitive.
-func (t *TextArea) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return t.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (t *TextArea) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return t.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		if t.disabled {
 			return
 		}
@@ -2332,6 +2332,8 @@ func (t *TextArea) InputHandler() func(event *tcell.EventKey, setFocus func(p Pr
 				defer t.changed()
 			}
 		}
+
+		return
 	})
 }
 

--- a/textview.go
+++ b/textview.go
@@ -1300,8 +1300,8 @@ func (t *TextView) Draw(screen tcell.Screen) {
 }
 
 // InputHandler returns the handler for this primitive.
-func (t *TextView) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return t.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (t *TextView) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return t.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		key := event.Key()
 
 		if key == tcell.KeyEscape || key == tcell.KeyEnter || key == tcell.KeyTab || key == tcell.KeyBacktab {
@@ -1360,6 +1360,8 @@ func (t *TextView) InputHandler() func(event *tcell.EventKey, setFocus func(p Pr
 			t.trackEnd = false
 			t.lineOffset -= t.pageSize
 		}
+
+		return
 	})
 }
 

--- a/treeview.go
+++ b/treeview.go
@@ -760,8 +760,8 @@ func (t *TreeView) Draw(screen tcell.Screen) {
 }
 
 // InputHandler returns the handler for this primitive.
-func (t *TreeView) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) {
-	return t.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) {
+func (t *TreeView) InputHandler() func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
+	return t.WrapInputHandler(func(event *tcell.EventKey, setFocus func(p Primitive)) (consumed bool) {
 		selectNode := func() {
 			node := t.currentNode
 			if node != nil {
@@ -823,6 +823,8 @@ func (t *TreeView) InputHandler() func(event *tcell.EventKey, setFocus func(p Pr
 		}
 
 		t.process(true)
+
+		return
 	})
 }
 


### PR DESCRIPTION
At present, it is not possible to (unless resorting to very unorthodox hacks) create inside-out event handler chains for keyboard events. This is useful in many applications (I ran into this with my first tview application), and is the default in the web world. 

This PR creates an option where a user can opt-in to create inside out keyboard event propagation, by adding an additional captureFunctionAfter. The default such function just captures all events (to preserve tview's current semantics), but you can override this to add your own logic, filter out some for passing back to parents etc.

In order for this to be possible, a bool return value of the InputHandler() and WrapInputHandler functions indicating event consumption was added.

Existing widget/primitive specific input handlers have not been given any event consumption semantics, as that would change tview's semantic overall, plus different applications may wish to customize this, so consuming inside the default input handlers would (I suspect) break tons of applications.


This PR is perhaps more of a proof of concept than a finished solution - I'd just like to get the discussion going (and hopefully, if this PR or a variant of it, in the future gets merged I can remove my incredibly ugly hacks to emulate this i my own apps :)) 

Perhaps there are better ways of doing this? The base idea is - I really think tview would be a lot easier in many situations if inside-out event propagation was possible - if that comes in this form of a PR like mine, or totally different impl doesn't matter that much to me