### PR TITLE
Fix app crash when clicking spaces after slide page items in presentation demo.

### DIFF
--- a/demos/presentation/main.go
+++ b/demos/presentation/main.go
@@ -55,6 +55,10 @@ func main() {
 		SetRegions(true).
 		SetWrap(false).
 		SetHighlightedFunc(func(added, removed, remaining []string) {
+			if len(added) == 0 {
+				return
+			}
+
 			pages.SwitchToPage(added[0])
 		})
 


### PR DESCRIPTION
The `SetHighlightedFunc` function is missing boundary check, so when clicking outside of available item list, it will panic with out of bound error.

https://github.com/rivo/tview/blob/c766eefb3803dc4d478ee18f4c9176918e1c09ac/demos/presentation/main.go#L57-L59

Fixed by checking slice length first.