### PR TITLE
fix(grid): order of adding items should not affect drawing

### DIFF
--- a/grid.go
+++ b/grid.go
@@ -272,8 +272,8 @@ func (g *Grid) Draw(screen tcell.Screen) {
 	x, y, width, height := g.GetInnerRect()
 	screenWidth, screenHeight := screen.Size()
 
-	// Make a list of items which apply.
-	items := make([]*gridItem, 0, len(g.items))
+	// Make a map of items that apply.
+	items := map[Primitive]*gridItem{}
 ItemLoop:
 	for _, item := range g.items {
 		item.visible = false
@@ -282,7 +282,7 @@ ItemLoop:
 		}
 
 		// Check for overlaps and multiple layouts of the same item.
-		for index, existing := range items {
+		for _, existing := range items {
 			// Do they overlap or are identical?
 			if item.Item != existing.Item &&
 				(item.Row >= existing.Row+existing.Height || item.Row+item.Height <= existing.Row ||
@@ -304,12 +304,12 @@ ItemLoop:
 			if itemMin < existingMin {
 				continue ItemLoop // This one isn't. Drop it.
 			}
-			items[index] = item // This one is. Replace the other.
+			items[item.Item] = item // This one is. Replace the other.
 			continue ItemLoop
 		}
 
 		// This item will be visible.
-		items = append(items, item)
+		items[item.Item] = item
 	}
 
 	// How many rows and columns do we have?


### PR DESCRIPTION
This PR is related to https://github.com/rivo/tview/issues/987

It seems that the order of adding items into the grid affects the result of the drawing.

This behaviour can be seen with the following example:
```go
package main

import (
	"github.com/rivo/tview"
)

func TestPage() {
	var dimensions []int
	for i := 0; i < 15; i++ {
		dimensions = append(dimensions, -1)
	}
	grid := tview.NewGrid().SetRows(dimensions...).SetColumns(dimensions...)
	// Set grid attributes
	grid.SetTitle("Manga Information").
		SetBorder(true)

	// Use a TextView for basic information of the manga.
	info := tview.NewTextView()
	// Set textview attributes
	info.SetWrap(true).SetWordWrap(true).
		SetTitle("About").
		SetBorder(true)

	// Use a table to show the chapters for the manga.
	table := tview.NewTable()
	// Set chapter headers
	numHeader := tview.NewTableCell("Chap").
		SetSelectable(false)
	titleHeader := tview.NewTableCell("Name").
		SetSelectable(false)
	downloadHeader := tview.NewTableCell("Download Status").
		SetSelectable(false)
	scanGroupHeader := tview.NewTableCell("ScanGroup").
		SetSelectable(false)
	readMarkerHeader := tview.NewTableCell("Read Status").
		SetSelectable(false)
	table.SetCell(0, 0, numHeader).
		SetCell(0, 1, titleHeader).
		SetCell(0, 2, downloadHeader).
		SetCell(0, 3, scanGroupHeader).
		SetCell(0, 4, readMarkerHeader).
		SetFixed(1, 0)
	// Set table attributes
	table.SetSelectable(true, false).
		SetSeparator('|').
		SetTitle("Chapters").
		SetBorder(true)

	// Add info and table to the grid. Set the focus to the chapter table.
	grid.AddItem(info, 0, 0, 5, 15, 0, 0, false).
		AddItem(table, 5, 0, 10, 15, 0, 0, true).
		AddItem(info, 0, 0, 15, 5, 0, 80, false).
		AddItem(table, 0, 5, 15, 10, 0, 80, true)

	if err := tview.NewApplication().SetRoot(grid, true).Run(); err != nil {
		panic(err)
	}
}

func main() {
	TestPage()
}
```

We expect the table to be shown differently based on the minimum widths and heights provided.
![image](https://github.com/rivo/tview/assets/53652695/26652e31-a1f8-4ae4-a677-c1779c24e6ae)
![image](https://github.com/rivo/tview/assets/53652695/8ef42406-7fc0-4d95-95d9-7c71d615ee33)


However, this is what we actually get - the table is shown twice in the large width view.
![image](https://github.com/rivo/tview/assets/53652695/384a67d3-8c7a-4d0b-9bb9-5a750c8e1ce8)
![image](https://github.com/rivo/tview/assets/53652695/8ef42406-7fc0-4d95-95d9-7c71d615ee33)

Strangely, if you change the order of adding of items to the grid, this unexpected behaviour disappears:
```go
	// Change order of adding to this
	grid.AddItem(info, 0, 0, 5, 15, 0, 0, false). // Info now added together
		AddItem(info, 0, 0, 15, 5, 0, 80, false).
		AddItem(table, 5, 0, 10, 15, 0, 0, true). // Table now added together
		AddItem(table, 0, 5, 15, 10, 0, 80, true)
	
	// Previously, this was the order
	grid.AddItem(info, 0, 0, 5, 15, 0, 0, false).
		AddItem(table, 5, 0, 10, 15, 0, 0, true).
		AddItem(info, 0, 0, 15, 5, 0, 80, false).
		AddItem(table, 0, 5, 15, 10, 0, 80, true)

```

It seems that using a `map` fixes this. This was also the original data structure used before https://github.com/rivo/tview/commit/33a1d271f2b6bae5ef63606df05275c2c91b2f86. No other logic is changed.