### PR TITLE
Fix unselected list color

### DIFF
--- a/list.go
+++ b/list.go
@@ -506,12 +506,16 @@ func (l *List) Draw(screen tcell.Screen) {
 		}
 
 		// Main text.
+		var printedWidth int
+		var style tcell.Style
 		selected := index == l.currentItem && (!l.selectedFocusOnly || l.HasFocus())
-		style := l.mainTextStyle
 		if selected {
 			style = l.selectedStyle
+			_, _, printedWidth = printWithStyle(screen, item.MainText, x, y, l.horizontalOffset, width, AlignLeft, style, false)
+		} else {
+			style = l.mainTextStyle
+			_, _, printedWidth = printWithStyle(screen, item.MainText, x, y, l.horizontalOffset, width, AlignLeft, style, true)
 		}
-		_, _, printedWidth := printWithStyle(screen, item.MainText, x, y, l.horizontalOffset, width, AlignLeft, style, false)
 		if printedWidth > maxWidth {
 			maxWidth = printedWidth
 		}


### PR DESCRIPTION
This patch is trying to fix #990.

The `maintainBackground` in `printWithStyle` function for the unselected list is set to true. I think this is desirable behavior for `DropDown`. But not sure if this would affect the `List`.