### PR TITLE
Remove abandoned project from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ For a presentation highlighting this package, compile and run the program found 
 - [Test your typing speed in the terminal!](https://github.com/shilangyu/typer-go)
 - [TUI Client for Docker](https://github.com/skanehira/docui)
 - [SSH client using certificates signed by HashiCorp Vault](https://github.com/stephane-martin/vssh)
-- [A go terminal based pos software.](https://github.com/thebmw/y2kpos)
 - [VMware vCenter Text UI](https://github.com/thebsdbox/vctui)
 - [Bookmarks on terminal](https://github.com/tryffel/bookmarker)
 - [A UDP testing utility](https://github.com/vaelen/udp-tester)


### PR DESCRIPTION
I got a bit excited to see this while looking through the projects in the readme, but it looks like all it ever did was import tview, then no one ever wrote any code and it was abandoned 5 years ago.