### PR TITLE
remove adjust offset on mouse click

### DIFF
--- a/list.go
+++ b/list.go
@@ -710,7 +710,7 @@ func (l *List) MouseHandler() func(action MouseAction, event *tcell.EventMouse, 
 					if l.changed != nil {
 						l.changed(index, item.MainText, item.SecondaryText, item.Shortcut)
 					}
-					l.adjustOffset()
+					//l.adjustOffset()
 				}
 				l.currentItem = index
 			}


### PR DESCRIPTION
adjustOffset will cause listbox offset change . As point of user, listbox will jump to wrong place. 
