### PR TITLE
do not reset the current attributes if the params has multi codes and prefixed with 0

### DIFF
--- a/ansi.go
+++ b/ansi.go
@@ -93,7 +93,7 @@ func (a *ansi) Write(text []byte) (int, error) {
 					var background, foreground string
 					params := a.csiParameter.String()
 					fields := strings.Split(params, ";")
-					if len(params) == 0 || fields[0] == "" || fields[0] == "0" {
+					if len(params) == 0 || len(fields) == 1 && (fields[0] == "" || fields[0] == "0") {
 						// Reset.
 						a.attributes = ""
 						if _, err := a.buffer.WriteString("[-:-:-]"); err != nil {


### PR DESCRIPTION
Fixes https://github.com/rivo/tview/issues/1081