### PR TITLE
docs: Add nerdlog to the list of projects using tview

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ For a presentation highlighting this package, compile and run the program found 
 - [chiko: Ultimate Beauty TUI gRPC Client](https://github.com/felangga/chiko)
 - [kmip-explorer: Browse & manage your KMIP objects from the terminal](https://github.com/phsym/kmip-explorer)
 - [stui: Slurm TUI for managing HPC clusters](https://github.com/antvirf/stui)
+- [nerdlog: Fast, remote-first, multi-host log viewer with timeline histogram](https://github.com/dimonomid/nerdlog)
 
 ## Documentation
 


### PR DESCRIPTION
Thanks for tview, it's awesome!

Here's one of my projects that uses it: [Nerdlog](https://github.com/dimonomid/nerdlog): a fast, remote-first, multi-host TUI log viewer with timeline histogram and no central server.