### PR TITLE
Improving Grid's focus handling and primitive nil checks

### DIFF
--- a/grid.go
+++ b/grid.go
@@ -206,6 +206,9 @@ func (g *Grid) AddItem(p Primitive, row, column, rowSpan, colSpan, minGridHeight
 			}
 		}
 	}
+	if p == nil {
+		return g
+	}
 	g.items = append(g.items, &gridItem{
 		Item:          p,
 		Row:           row,


### PR DESCRIPTION
Hey, love the library. I was playing around with the Grid view and noticed that the Grid.AddItem wouldn't respect the focus boolean sometimes. Then I checked the Draw method for the Grid and noticed that only the one element is picked for focus during a draw and it's not necessarily the latest one added. 

A small sidequest: When a nil primitive is added to the Grid, it will panic when trying to deal with inputHandling. So I just added a check for p == nil to prevent nil primitives from being added to the table. This way, whomever is using this library can just insert things into the Grid without having to nil check all over the place.

You can test this by making a split pane grid and then adding two tables into each pane. It'll work the first time you call AddItem on any Primitive, but subsiquent AddItems call will mess up the focus. (maybe i'm using it wrong ?)

my test repo: https://github.com/zveinn/term-test

```go
	// Calculate primitive positions.
	var focus *gridItem // The item which has focus.
	for _, item := range items {
		px := columnPos[item.Column]
		py := rowPos[item.Row]
		var pw, ph int
		for index := 0; index < item.Height; index++ {
			ph += rowHeight[item.Row+index]
		}
		for index := 0; index < item.Width; index++ {
			pw += columnWidth[item.Column+index]
		}
		if g.borders {
			pw += item.Width - 1
			ph += item.Height - 1
		} else {
			pw += (item.Width - 1) * g.gapColumns
			ph += (item.Height - 1) * g.gapRows
		}
		item.x, item.y, item.w, item.h = px, py, pw, ph
		item.visible = true
		if item.Item.HasFocus() {
			focus = item
		}
	}
```
So I wrote a small loop to clear focus on all elements to force focus on the added item (only if focus is true)

I'm not sure if it's intended to have multiple elements within a grid that can have focus at the same time, if so then feel free to close the PR. 
