### PR TITLE
fix(tags): Check for end-of-string within "[]" case

### DIFF
--- a/strings.go
+++ b/strings.go
@@ -157,6 +157,11 @@ func step(str string, state *stepState, opts stepOptions) (cluster, rest string,
 				// Swallow the first one.
 				cluster, rest, state.boundaries, state.unisegState = uniseg.StepString(rest, preState)
 				state.grossLength += len(cluster)
+				if rest == "" {
+					if !uniseg.HasTrailingLineBreakInString(cluster) {
+						state.boundaries &^= uniseg.MaskLine
+					}
+				}
 				if cluster[0] == ']' {
 					state.escapedTagState = etNone
 				} else {


### PR DESCRIPTION
There's a bug that makes `[something[]` be parsed as `[something]\n` if it was at the end of the input string instead of `[something]`. This patch fixes it.