### PR TITLE
feat: new BoxedPrimitive interface implemented by *Box

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | { read -r f; case \"$f\" in *.go) gofmt -w \"$f\";; esac; } 2>/dev/null || true",
+            "statusMessage": "Running gofmt..."
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | { read -r f; case \"$f\" in *.go) output=$(golangci-lint run \"$f\" 2>&1); rc=$?; if [ $rc -ne 0 ]; then jq -n --arg ctx \"golangci-lint found issues in $f. Fix them:\\n$output\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":$ctx}}'; exit $rc; fi;; esac; }",
+            "statusMessage": "Running golangci-lint..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/box.go
+++ b/box.go
@@ -96,6 +96,11 @@ func NewBox() *Box {
 	return b
 }
 
+// GetBox returns the box itself implementing the BoxedPrimitive interface.
+func (b *Box) GetBox() *Box {
+	return b
+}
+
 // SetBorderPadding sets the size of the borders around the box content.
 func (b *Box) SetBorderPadding(top, bottom, left, right int) *Box {
 	b.paddingTop, b.paddingBottom, b.paddingLeft, b.paddingRight = top, bottom, left, right

--- a/box_test.go
+++ b/box_test.go
@@ -1,0 +1,89 @@
+package tview
+
+import (
+	"testing"
+)
+
+func Test_GetBox(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		getBox func() (BoxedPrimitive, *Box)
+	}{
+		{name: "Box", getBox: func() (BoxedPrimitive, *Box) {
+			box := NewBox()
+			return box, box
+		}},
+		{name: "Button", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewButton("Click me")
+			return p, p.Box
+		}},
+		{name: "Checkbox", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewCheckbox()
+			return p, p.Box
+		}},
+		{name: "DropDown", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewDropDown()
+			return p, p.Box
+		}},
+		{name: "Flex", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewFlex()
+			return p, p.Box
+		}},
+		{name: "Form", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewForm()
+			return p, p.Box
+		}},
+		{name: "Frame", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewFrame(NewTextView())
+			return p, p.Box
+		}},
+		{name: "Grid", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewGrid()
+			return p, p.Box
+		}},
+		{name: "Image", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewImage()
+			return p, p.Box
+		}},
+		{name: "InputField", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewInputField()
+			return p, p.Box
+		}},
+		{name: "List", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewList()
+			return p, p.Box
+		}},
+		{name: "Modal", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewModal()
+			return p, p.Box
+		}},
+		{name: "Pages", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewPages()
+			return p, p.Box
+		}},
+		{name: "Table", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewTable()
+			return p, p.Box
+		}},
+		{name: "TextArea()", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewTextArea()
+			return p, p.Box
+		}},
+		{name: "TextView", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewTextView()
+			return p, p.Box
+		}},
+		{name: "TreeView", getBox: func() (BoxedPrimitive, *Box) {
+			p := NewTextView()
+			return p, p.Box
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			primitive, box := tt.getBox()
+			actualBox := primitive.GetBox()
+			if actualBox != box {
+				t.Errorf("GetBox() got = %+v\nwant %+v", actualBox, box)
+			}
+		})
+	}
+}

--- a/boxed_primitive.go
+++ b/boxed_primitive.go
@@ -1,0 +1,8 @@
+package tview
+
+// BoxedPrimitive defines a primitive with a Box
+// It's implemented by Box and any type that has *Box field
+type BoxedPrimitive interface {
+	Primitive
+	GetBox() *Box
+}


### PR DESCRIPTION
Resolve #1140

Often we'd want to work with set of primitives that are boxed (e.g. have `*Box` field)

This for example needed for managing borders state/color in general way in multi-panels layout.

This PR introduces:
```go
// BoxedPrimitive defines a primitive with a Box
// It's implemented by Box and any type that has *Box field
type BoxedPrimitive interface {
	Primitive
	GetBox() *Box
}
```

That is implemented by:
```go
// GetBox returns the box itself implementing the BoxedPrimitive interface.
func (b *Box) GetBox() *Box {
	return b
}
```

This allows to have code like:

```go
var panels := []tview.BoxedPrimitive

for _, p := range panels {
  p.GetBox().SetBorderColor(someColor)
}
```

I've added test but if needed I can remove them.

Let me know if I need to make any adjustments - I'm open to feedback. 