### PR TITLE
add fault handler to prevent terminal breaking on application faults

### DIFF
--- a/application.go
+++ b/application.go
@@ -1,6 +1,7 @@
 package tview
 
 import (
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -325,6 +326,16 @@ func (a *Application) Run() error {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
+		debug.SetPanicOnFault(true)
+		defer func() {
+			if p := recover(); p != nil {
+				if a.screen != nil {
+					a.screen.Fini()
+				}
+				panic(p)
+			}
+		}()
+
 		defer wg.Done()
 		for {
 			a.RLock()


### PR DESCRIPTION
If an application using tview runs into a non-panic fault it will not run Fini() and can leave the terminal in a bad state.

This causes those non-panic faults to create panics with [`debug.SetPanicOnFault`](https://pkg.go.dev/runtime/debug#SetPanicOnFault) and be caught, and attempt to Fini().