### PR TITLE
table: stop InputHandler hanging when every cell is non-selectable

### DIFF
--- a/table.go
+++ b/table.go
@@ -1392,8 +1392,22 @@ func (t *Table) InputHandler() func(event *tcell.EventKey, setFocus func(p Primi
 		}
 		var (
 			// Move the selection forward, don't go beyond final cell, return
-			// true if a selection was found.
+			// true if a selection was found. finalRow/finalColumn are clamped
+			// to the valid table range so the loop is guaranteed to terminate
+			// even when the caller asks for an unreachable bound (e.g. after
+			// a previous Draw left t.selectedRow == rowCount because nothing
+			// in the table is selectable).
 			forward = func(finalRow, finalColumn int) bool {
+				if finalRow < 0 {
+					finalRow = 0
+				} else if finalRow > rowCount-1 {
+					finalRow = rowCount - 1
+				}
+				if finalColumn < 0 {
+					finalColumn = 0
+				} else if finalColumn > lastColumn {
+					finalColumn = lastColumn
+				}
 				row, column := t.selectedRow, t.selectedColumn
 				for {
 					// Stop if the current selection is fine.
@@ -1421,8 +1435,19 @@ func (t *Table) InputHandler() func(event *tcell.EventKey, setFocus func(p Primi
 			}
 
 			// Move the selection backwards, don't go beyond final cell, return
-			// true if a selection was found.
+			// true if a selection was found. See forward for the rationale
+			// behind clamping finalRow/finalColumn.
 			backwards = func(finalRow, finalColumn int) bool {
+				if finalRow < 0 {
+					finalRow = 0
+				} else if finalRow > rowCount-1 {
+					finalRow = rowCount - 1
+				}
+				if finalColumn < 0 {
+					finalColumn = 0
+				} else if finalColumn > lastColumn {
+					finalColumn = lastColumn
+				}
 				row, column := t.selectedRow, t.selectedColumn
 				for {
 					// Stop if the current selection is fine.

--- a/table_test.go
+++ b/table_test.go
@@ -1,0 +1,37 @@
+package tview
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+)
+
+// TestTableInputHandlerNoSelectableCells covers the case where every cell in
+// the table is non-selectable. Before the forward/backwards clamping, the
+// down-arrow handler entered an unbounded loop in this scenario because a
+// previous Draw left t.selectedRow == rowCount, which the input handler then
+// passed as an unreachable finalRow target to backwards. See rivo/tview#1146.
+func TestTableInputHandlerNoSelectableCells(t *testing.T) {
+	table := NewTable().SetSelectable(true, false)
+	for i, col := range []string{"cpu", "memory", "disk"} {
+		table.SetCell(0, i, NewTableCell(col).SetSelectable(false))
+	}
+
+	// Simulate the state Draw leaves behind when nothing is selectable: it
+	// walks selectedRow past the last row.
+	table.selectedRow = table.GetRowCount()
+	table.selectedColumn = 0
+
+	done := make(chan struct{})
+	go func() {
+		table.InputHandler()(tcell.NewEventKey(tcell.KeyDown, ' ', 0), func(Primitive) {})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("InputHandler hung on KeyDown when every cell is non-selectable")
+	}
+}


### PR DESCRIPTION
Reproducer from #1146:

```go
t := tview.NewTable()
t.SetFixed(1, 2).SetSelectable(true, false)
for i, col := range []string{"cpu", "memory", "disk"} {
    t.SetCell(0, i, tview.NewTableCell(col).SetSelectable(false))
}
app := tview.NewApplication()
app.SetRoot(t, true).SetFocus(t).Run()
```

Press the down arrow once and the process pegs a CPU core.

Tracing what happens:

1. The first `Draw` runs the "find next selectable cell" loop at table.go:898 and, because nothing is selectable, walks `selectedRow` all the way to `rowCount` and bails out.
2. The next `KeyDown` enters the `down` movement function, captures `row, column := t.selectedRow, t.selectedColumn` (`row = rowCount` here), updates `t.selectedRow` and falls through to `forward(rowCount-1, lastColumn)`.
3. `forward` walks every cell, finds nothing selectable, hits its `finalRow/finalColumn` and returns false.
4. `down` then calls `backwards(row, column)`, i.e. `backwards(rowCount, 0)`. The wraparound inside `backwards` only ever takes `row` as low as `rowCount-1`, so it can never reach `rowCount` and the loop never terminates.

Same shape on the up/left/right side: any handler that uses the pre-move `row, column` as the rollback target will hang once `Draw` has poisoned `selectedRow`.

Fix is to clamp `finalRow`/`finalColumn` to the valid range at the top of `forward` and `backwards`. Any target the caller passes is then reachable, so the loops are guaranteed to terminate. The clamp is the only behaviour change; in every reachable case the values are already inside the range, so existing callers see the same result.

Added a regression test that constructs the bad state explicitly and runs `InputHandler` under a 1-second timeout. Fails on master, passes here. `go test ./...` is clean.

Fixes #1146.
