### PR TITLE
Keep mouse-wheel scroll position when clicking a tree node

### DIFF
--- a/treeview.go
+++ b/treeview.go
@@ -317,6 +317,11 @@ type TreeView struct {
 	// scrolling.
 	step int
 
+	// Set to true when the user scrolls with the mouse wheel without moving the
+	// selection. While set, Draw() will not scroll the selected node back into
+	// view (which would undo the scroll). Reset when the selection changes.
+	userScrolled bool
+
 	// The top hierarchical level shown. (0 corresponds to the root level.)
 	topLevel int
 
@@ -654,13 +659,25 @@ func (t *TreeView) process(drawingAfter bool) {
 		}
 		t.currentNode = t.nodes[selectedIndex]
 
-		// Move selection into viewport.
+		// A change of the selection cancels a user scroll, so the selected node
+		// is moved back into the viewport below.
+		if t.currentNode != t.lastNode {
+			t.userScrolled = false
+		}
+
+		// Move the selection into the viewport, unless the user has scrolled with
+		// the mouse wheel: doing so here would undo that scroll on the redraw
+		// caused by the mouse button-press, and the following click would then
+		// select the wrong node. A resize or a change to the tree still moves the
+		// selection into view, as neither sets userScrolled.
 		if t.movement != treeScroll {
-			if selectedIndex-t.offsetY >= height {
-				t.offsetY = selectedIndex - height + 1
-			}
-			if selectedIndex < t.offsetY {
-				t.offsetY = selectedIndex
+			if !t.userScrolled {
+				if selectedIndex-t.offsetY >= height {
+					t.offsetY = selectedIndex - height + 1
+				}
+				if selectedIndex < t.offsetY {
+					t.offsetY = selectedIndex
+				}
 			}
 			if t.movement != treeHome && t.movement != treeEnd {
 				// treeScroll, treeHome, and treeEnd are handled by Draw().
@@ -900,10 +917,12 @@ func (t *TreeView) MouseHandler() func(action MouseAction, event *tcell.EventMou
 		case MouseScrollUp:
 			t.movement = treeScroll
 			t.step = -1
+			t.userScrolled = true
 			consumed = true
 		case MouseScrollDown:
 			t.movement = treeScroll
 			t.step = 1
+			t.userScrolled = true
 			consumed = true
 		}
 


### PR DESCRIPTION
Fixes #1044 

After scrolling a TreeView with the mouse wheel and then clicking a
visible node, the wrong node ends up selected. The mouse button-press
triggers a redraw, and `process()` scrolls the selected node back into
view before the click is resolved, which shifts the rows out from under
the cursor so the following click lands on a different node.

This tracks when the user has scrolled with the mouse wheel and skips the
scroll-into-view step in `process()` while that is the case. The flag is
reset as soon as the selection actually changes, so keyboard navigation,
resizes, and changes to the tree still move the selection into view as
before.

To reproduce, build a tree taller than its viewport, scroll with the
mouse wheel until the selected node is off-screen, and click a visible
node. Before this change a different node is selected.

Listbox doesn't have this issue anymore so no changes are needed there.